### PR TITLE
feat: add io_text

### DIFF
--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47942F227F6B0027A012 /* RPCMethodHandler.swift */; };
 		787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */; };
 		787C479A2F227F6B0027A012 /* JSONRPCDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47922F227F6B0027A012 /* JSONRPCDispatcher.swift */; };
-		787C47DF2F228B770027A012 /* Tap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47DD2F228B770027A012 /* Tap.swift */; };
+		787C47DF2F228B770027A012 /* IOTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47DD2F228B770027A012 /* IOTap.swift */; };
 		787C47E02F228B770027A012 /* DumpUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47DC2F228B770027A012 /* DumpUI.swift */; };
 		787C48462F228D8D0027A012 /* JSONRPCHTTPHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C48452F228D8C0027A012 /* JSONRPCHTTPHandler.swift */; };
 		787C48482F228D960027A012 /* JSONRPCMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C48472F228D950027A012 /* JSONRPCMessageHandler.swift */; };
@@ -240,7 +240,7 @@
 		787C47942F227F6B0027A012 /* RPCMethodHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCMethodHandler.swift; sourceTree = "<group>"; };
 		787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestWebSocketServer.swift; sourceTree = "<group>"; };
 		787C47DC2F228B770027A012 /* DumpUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DumpUI.swift; sourceTree = "<group>"; };
-		787C47DD2F228B770027A012 /* Tap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tap.swift; sourceTree = "<group>"; };
+		787C47DD2F228B770027A012 /* IOTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOTap.swift; sourceTree = "<group>"; };
 		787C48452F228D8C0027A012 /* JSONRPCHTTPHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCHTTPHandler.swift; sourceTree = "<group>"; };
 		787C48472F228D950027A012 /* JSONRPCMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCMessageHandler.swift; sourceTree = "<group>"; };
 		787C95972F17F23500AB3BF1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -554,7 +554,7 @@
 			isa = PBXGroup;
 			children = (
 				787C47DC2F228B770027A012 /* DumpUI.swift */,
-				787C47DD2F228B770027A012 /* Tap.swift */,
+				787C47DD2F228B770027A012 /* IOTap.swift */,
 			);
 			path = Handlers;
 			sourceTree = "<group>";
@@ -788,7 +788,7 @@
 				521C1F072D8017480024EE42 /* AXClientProxy.m in Sources */,
 				5261117A2DE5E8E7007C356B /* XCAXClient_iOS+FBSnapshotReqParams.m in Sources */,
 				610D58FB2A49E3CA00B4BBEB /* AXClientSwizzler.swift in Sources */,
-				787C47DF2F228B770027A012 /* Tap.swift in Sources */,
+				787C47DF2F228B770027A012 /* IOTap.swift in Sources */,
 				787C47E02F228B770027A012 /* DumpUI.swift in Sources */,
 				521C1F102D8051FC0024EE42 /* XCTestDaemonsProxy.m in Sources */,
 				613E87D7299A64BD00FF8551 /* PointerEventPath.swift in Sources */,

--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		612DE4122984114B003C2BE0 /* RunnerDaemonProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612DE4112984114B003C2BE0 /* RunnerDaemonProxy.swift */; };
 		612DE414298426EF003C2BE0 /* EventRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612DE413298426EF003C2BE0 /* EventRecord.swift */; };
 		613E87D7299A64BD00FF8551 /* PointerEventPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E87D6299A64BD00FF8551 /* PointerEventPath.swift */; };
+		78147F0F2F27AA6B00E61E3B /* IOText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147F0E2F27AA6B00E61E3B /* IOText.swift */; };
 		787C47972F227F6B0027A012 /* JSONRPCModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47932F227F6B0027A012 /* JSONRPCModels.swift */; };
 		787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47942F227F6B0027A012 /* RPCMethodHandler.swift */; };
 		787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */; };
@@ -235,6 +236,7 @@
 		612DE4112984114B003C2BE0 /* RunnerDaemonProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerDaemonProxy.swift; sourceTree = "<group>"; };
 		612DE413298426EF003C2BE0 /* EventRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventRecord.swift; sourceTree = "<group>"; };
 		613E87D6299A64BD00FF8551 /* PointerEventPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointerEventPath.swift; sourceTree = "<group>"; };
+		78147F0E2F27AA6B00E61E3B /* IOText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOText.swift; sourceTree = "<group>"; };
 		787C47922F227F6B0027A012 /* JSONRPCDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCDispatcher.swift; sourceTree = "<group>"; };
 		787C47932F227F6B0027A012 /* JSONRPCModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCModels.swift; sourceTree = "<group>"; };
 		787C47942F227F6B0027A012 /* RPCMethodHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCMethodHandler.swift; sourceTree = "<group>"; };
@@ -553,6 +555,7 @@
 		787C47DE2F228B770027A012 /* Handlers */ = {
 			isa = PBXGroup;
 			children = (
+				78147F0E2F27AA6B00E61E3B /* IOText.swift */,
 				787C47DC2F228B770027A012 /* DumpUI.swift */,
 				787C47DD2F228B770027A012 /* IOTap.swift */,
 			);
@@ -803,6 +806,7 @@
 				52D8FA9D2D6DCFAF0015FAB3 /* XCUIApplicationProcess+FBQuiescence.m in Sources */,
 				52049BF8293503A200807AA3 /* devicekit_iosUITests.swift in Sources */,
 				52D8FAB02D6DD4100015FAB3 /* FBConfiguration.m in Sources */,
+				78147F0F2F27AA6B00E61E3B /* IOText.swift in Sources */,
 				6124329E2A4DA5BB00F5F619 /* AXElement.swift in Sources */,
 				52E35D432A654F67001D97A8 /* RunningApp.swift in Sources */,
 				52D8FAB42D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.m in Sources */,

--- a/devicekit-iosUITests/JSONRPC/Handlers/DumpUI.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/DumpUI.swift
@@ -116,7 +116,7 @@ struct DumpUIMethodHandler: RPCMethodHandler {
         do {
             let foregroundApp = RunningApp.getForegroundApp()
             guard let foregroundApp = foregroundApp else {
-                NSLog("No foreground app found returning springboard app hierarchy")
+                logger.warning("No foreground app found returning springboard app hierarchy")
                 let springboardHierarchy = try elementHierarchy(xcuiElement: springboardApplication)
                 let viewHierarchy = ViewHierarchy(
                     axElement: springboardHierarchy,
@@ -125,7 +125,7 @@ struct DumpUIMethodHandler: RPCMethodHandler {
                 return try JSONValue.from(viewHierarchy)
             }
 
-            NSLog("[Start] View hierarchy snapshot for \(foregroundApp)")
+            logger.info("[Start] View hierarchy snapshot for \(foregroundApp)")
             let appViewHierarchy = try logger.measure(
                 message: "View hierarchy snapshot for \(foregroundApp)"
             ) {
@@ -139,7 +139,7 @@ struct DumpUIMethodHandler: RPCMethodHandler {
                 depth: appViewHierarchy.depth()
             )
 
-            NSLog("[Done] View hierarchy snapshot for \(foregroundApp)")
+            logger.info("[Done] View hierarchy snapshot for \(foregroundApp)")
             return try JSONValue.from(viewHierarchy)
         } catch let error as RPCMethodError {
             throw error
@@ -265,7 +265,7 @@ struct DumpUIMethodHandler: RPCMethodHandler {
                 throw error
             }
 
-            NSLog("Snapshot failure, getting recovery element for fallback")
+            logger.error("Snapshot failure, getting recovery element for fallback")
             AXClientSwizzler.overwriteDefaultParameters["maxDepth"] = snapshotMaxDepth
 
             let recoveryElement = try findRecoveryElement(element.children(matching: .any).firstMatch)
@@ -332,15 +332,15 @@ struct DumpUIMethodHandler: RPCMethodHandler {
         let webViewCount = safariWebService.webViews.count
         guard webViewCount > 0 else { return nil }
 
-        NSLog("[Start] Fetching Safari WebView hierarchy (\(webViewCount) webview(s) detected)")
+        logger.info("[Start] Fetching Safari WebView hierarchy (\(webViewCount) webview(s) detected)")
 
         do {
             AXClientSwizzler.overwriteDefaultParameters["maxDepth"] = snapshotMaxDepth
             let safariHierarchy = try elementHierarchy(xcuiElement: safariWebService)
-            NSLog("[Done] Safari WebView hierarchy fetched successfully")
+            logger.info("[Done] Safari WebView hierarchy fetched successfully")
             return safariHierarchy
         } catch {
-            NSLog("[Error] Failed to fetch Safari WebView hierarchy: \(error.localizedDescription)")
+            logger.error("[Error] Failed to fetch Safari WebView hierarchy: \(error.localizedDescription)")
             return nil
         }
     }

--- a/devicekit-iosUITests/JSONRPC/Handlers/DumpUI.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/DumpUI.swift
@@ -20,9 +20,9 @@ extension Logger {
     }
 }
 
-// MARK: - DumpUI Request Model
+// MARK: - dump_ui Request Model
 
-/// Request body for the `/dumpUI` endpoint.
+/// Request body for the `/dump_ui` endpoint.
 ///
 /// This model represents the JSON payload for capturing the UI view hierarchy.
 ///
@@ -37,17 +37,17 @@ extension Logger {
 /// ## curl Examples
 /// ```bash
 /// # Capture full UI hierarchy
-/// curl -X POST http://127.0.0.1:12004/dumpUI \
+/// curl -X POST http://127.0.0.1:12004/dump_ui \
 ///     -H "Content-Type: application/json" \
 ///     -d '{"appIds": [], "excludeKeyboardElements": false}'
 ///
 /// # Exclude keyboard from hierarchy
-/// curl -X POST http://127.0.0.1:12004/dumpUI \
+/// curl -X POST http://127.0.0.1:12004/dump_ui \
 ///     -H "Content-Type: application/json" \
 ///     -d '{"appIds": [], "excludeKeyboardElements": true}'
 ///
 /// # Pretty-print JSON output
-/// curl -X POST http://127.0.0.1:12004/dumpUI \
+/// curl -X POST http://127.0.0.1:12004/dump_ui \
 ///     -H "Content-Type: application/json" \
 ///     -d '{"appIds": [], "excludeKeyboardElements": false}' | jq .
 /// ```
@@ -64,9 +64,9 @@ struct DumpUIRequest: Codable {
     let excludeKeyboardElements: Bool
 }
 
-// MARK: - DumpUI Method Handler
+// MARK: - dump_ui Method Handler
 
-/// JSON-RPC handler for the `dumpUI` method.
+/// JSON-RPC handler for the `dump_ui` method.
 ///
 /// Captures the complete UI view hierarchy.
 ///
@@ -82,7 +82,7 @@ struct DumpUIRequest: Codable {
 /// Returns the view hierarchy as a nested JSON object.
 @MainActor
 struct DumpUIMethodHandler: RPCMethodHandler {
-    static let methodName = "dumpUI"
+    static let methodName = "dump_ui"
 
     private let springboardApplication = XCUIApplication(
         bundleIdentifier: "com.apple.springboard"
@@ -96,7 +96,7 @@ struct DumpUIMethodHandler: RPCMethodHandler {
 
     func execute(params: JSONValue?) async throws -> JSONValue {
         guard let params = params else {
-            throw RPCMethodError.invalidParams("Missing parameters for dumpUI method")
+            throw RPCMethodError.invalidParams("Missing parameters for dump_ui method")
         }
 
         let paramsData: Data
@@ -110,7 +110,7 @@ struct DumpUIMethodHandler: RPCMethodHandler {
         do {
             request = try JSONDecoder().decode(DumpUIRequest.self, from: paramsData)
         } catch {
-            throw RPCMethodError.invalidParams("Invalid dumpUI parameters: \(error.localizedDescription)")
+            throw RPCMethodError.invalidParams("Invalid dump_ui parameters: \(error.localizedDescription)")
         }
 
         do {

--- a/devicekit-iosUITests/JSONRPC/Handlers/IOTap.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/IOTap.swift
@@ -97,9 +97,9 @@ struct IOTapMethodHandler: RPCMethodHandler {
         let (x, y) = (point.x, point.y)
 
         if request.duration != nil {
-            NSLog("Long pressing \(x), \(y) for \(request.duration!)s")
+            logger.info("Long pressing \(x), \(y) for \(request.duration!)s")
         } else {
-            NSLog("Tapping \(x), \(y)")
+            logger.info("Tapping \(x), \(y)")
         }
 
         do {
@@ -111,10 +111,10 @@ struct IOTapMethodHandler: RPCMethodHandler {
             let start = Date()
             try await RunnerDaemonProxy().synthesize(eventRecord: eventRecord)
             let duration = Date().timeIntervalSince(start)
-            NSLog("Tapping took \(duration)")
+            logger.info("Tapping took \(duration)")
             return .object(["success": .bool(true)])
         } catch {
-            NSLog("Error tapping: \(error)")
+            logger.error("Error tapping: \(error)")
             throw RPCMethodError.internalError("Error tapping point: \(error.localizedDescription)")
         }
     }

--- a/devicekit-iosUITests/JSONRPC/Handlers/IOTap.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/IOTap.swift
@@ -2,7 +2,7 @@ import os
 
 // MARK: - Tap Request Model
 
-/// Request body for the `/tap` endpoint.
+/// Request body for the `/io_tap` endpoint.
 ///
 /// This model represents the JSON payload for tap and long-press gestures.
 ///
@@ -18,16 +18,16 @@ import os
 /// ## curl Example
 /// ```bash
 /// # Simple tap
-// curl -X POST http://127.0.0.1:12004/tap \
+// curl -X POST http://127.0.0.1:12004/io_tap \
 //     -H "Content-Type: application/json" \
 //     -d '{"x": 100.0, "y": 200.0}'
 ///
 /// # Long-press for 1.5 seconds
-/// curl -X POST http://127.0.0.1:12004/tap \
+/// curl -X POST http://127.0.0.1:12004/io_tap \
 ///     -H "Content-Type: application/json" \
 ///     -d '{"x": 100.0, "y": 200.0, "duration": 1.5}'
 /// ```
-struct TapRequest: Codable {
+struct IOTapRequest: Codable {
 
     /// X coordinate in screen points.
     let x: Float
@@ -43,7 +43,7 @@ struct TapRequest: Codable {
 
 // MARK: - Tap Method Handler
 
-/// JSON-RPC handler for the `tap` method.
+/// JSON-RPC handler for the `io_tap` method.
 ///
 /// Performs tap or long-press gestures at screen coordinates.
 ///
@@ -61,8 +61,8 @@ struct TapRequest: Codable {
 /// {"success": true}
 /// ```
 @MainActor
-struct TapMethodHandler: RPCMethodHandler {
-    static let methodName = "tap"
+struct IOTapMethodHandler: RPCMethodHandler {
+    static let methodName = "io_tap"
 
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!,
@@ -71,7 +71,7 @@ struct TapMethodHandler: RPCMethodHandler {
 
     func execute(params: JSONValue?) async throws -> JSONValue {
         guard let params = params else {
-            throw RPCMethodError.invalidParams("Missing parameters for tap method")
+            throw RPCMethodError.invalidParams("Missing parameters for io_tap method")
         }
 
         let paramsData: Data
@@ -81,11 +81,11 @@ struct TapMethodHandler: RPCMethodHandler {
             throw RPCMethodError.invalidParams("Failed to serialize params: \(error.localizedDescription)")
         }
 
-        let request: TapRequest
+        let request: IOTapRequest
         do {
-            request = try JSONDecoder().decode(TapRequest.self, from: paramsData)
+            request = try JSONDecoder().decode(IOTapRequest.self, from: paramsData)
         } catch {
-            throw RPCMethodError.invalidParams("Invalid tap parameters: \(error.localizedDescription)")
+            throw RPCMethodError.invalidParams("Invalid io_tap parameters: \(error.localizedDescription)")
         }
 
         let (width, height) = OrientationGeometry.physicalScreenSize()

--- a/devicekit-iosUITests/JSONRPC/Handlers/IOText.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/IOText.swift
@@ -1,0 +1,212 @@
+import FlyingFox
+import XCTest
+import os
+
+// MARK: - Constants
+
+/// Configuration constants for text input behavior.
+private enum Constants {
+    /// Default typing frequency for bulk text input (characters per second).
+    /// Higher values result in faster typing but may cause iOS to drop characters.
+    static let typingFrequency = 30
+
+    /// Number of initial characters to type at a slower speed.
+    /// This helps avoid character drops due to keyboard listeners (autocorrection, etc.).
+    static let slowInputCharactersCount = 1
+}
+
+// MARK: - Request Model
+
+/// Parameters for the `io_text` JSON-RPC method.
+///
+/// ## JSON Format
+/// ```json
+/// {
+///   "text": "Hello, World!",
+///   "deviceId": "ID"
+/// }
+/// ```
+///
+/// ## Fields
+/// - `text`: The text string to input into the currently focused text field.
+/// - `deviceId`: Reserved for future use. Currently unused but required for API compatibility.
+///
+/// ## Example Request
+/// ```json
+/// {
+///   "jsonrpc": "2.0",
+///   "method": "io_text",
+///   "params": {
+///     "text": "test@example.com",
+///     "deviceId": "your_device_id"
+///   },
+///   "id": 1
+/// }
+/// ```
+struct IOTextRequest: Codable {
+    /// The text to input into the focused text field.
+    let text: String
+
+    /// Reserved for future use. Pass an empty array.
+    let deviceId: String
+}
+
+// MARK: - Handler
+
+/// JSON-RPC method handler for text input operations.
+///
+/// This handler synthesizes keyboard input events to type text into the currently
+/// focused text field on the device. It uses XCTest's private APIs to generate
+/// authentic keyboard events.
+///
+/// ## Method Name
+/// `io_text`
+///
+/// ## Prerequisites
+/// - A text field must be focused and the keyboard must be visible.
+/// - The handler waits up to 1 second for the keyboard to appear.
+///
+/// ## Implementation Notes
+/// To avoid iOS dropping characters (a common issue with synthetic keyboard input),
+/// the handler uses a two-phase approach:
+/// 1. Types the first character at a slow speed (frequency = 1)
+/// 2. Waits 500ms for iOS to stabilize
+/// 3. Types remaining characters at normal speed (frequency = 30)
+///
+/// ## Response
+/// ```json
+/// {
+///   "jsonrpc": "2.0",
+///   "result": { "success": true },
+///   "id": 1
+/// }
+/// ```
+///
+/// ## Errors
+/// - `-32602`: Invalid parameters (missing or malformed request)
+/// - `-32603`: Internal error (keyboard not visible, text input failed)
+@MainActor
+struct IOTextMethodHandler: RPCMethodHandler {
+
+    /// The JSON-RPC method name this handler responds to.
+    static let methodName = "io_text"
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: Self.self)
+    )
+
+    /// Executes the text input operation.
+    ///
+    /// - Parameter params: JSON-RPC parameters containing the text to input.
+    /// - Returns: A JSON object with `success: true` on successful input.
+    /// - Throws: `RPCMethodError.invalidParams` if parameters are invalid,
+    ///           `RPCMethodError.internalError` if text input fails.
+    func execute(params: JSONValue?) async throws -> JSONValue {
+        guard let params = params else {
+            throw RPCMethodError.invalidParams("Missing parameters for io_text method")
+        }
+
+        let paramsData: Data
+        do {
+            paramsData = try params.toData()
+        } catch {
+            throw RPCMethodError.invalidParams("Failed to serialize params: \(error.localizedDescription)")
+        }
+
+        let request: IOTextRequest
+        do {
+            request = try JSONDecoder().decode(IOTextRequest.self, from: paramsData)
+        } catch {
+            throw RPCMethodError.invalidParams("Invalid io_text parameters: \(error.localizedDescription)")
+        }
+
+        do {
+            let start = Date()
+
+            await waitUntilKeyboardIsPresented()
+
+            try await inputText(request.text)
+
+            let duration = Date().timeIntervalSince(start)
+            logger.info("Text input duration took \(duration)")
+            return .object(["success": .bool(true)])
+        } catch {
+            logger.error("Error inputting text: \(error)")
+            throw RPCMethodError.internalError("Error inputting text: \(error.localizedDescription)")
+        }
+    }
+
+    /// Waits for the keyboard to become visible on screen.
+    ///
+    /// Polls every 200ms for up to 1 second checking if any keyboard is present
+    /// in the foreground application or SpringBoard.
+    private func waitUntilKeyboardIsPresented() async {
+        try? await repeatUntil(timeout: 1, delta: 0.2) {
+            let app = RunningApp.getForegroundApp() ?? XCUIApplication(bundleIdentifier: RunningApp.springboardBundleId)
+
+            return app.keyboards.firstMatch.exists
+        }
+    }
+
+    /// Synthesizes keyboard input events to type the given text.
+    ///
+    /// Uses a two-phase approach to avoid character drops:
+    /// 1. **Phase 1**: Types the first character at speed 1 (slowest)
+    /// 2. **Delay**: Waits 500ms for iOS input system to stabilize
+    /// 3. **Phase 2**: Types remaining characters at normal speed (30 chars/sec)
+    ///
+    /// - Parameter text: The text string to type.
+    /// - Throws: Error if event synthesis fails.
+    private func inputText(_ text: String) async throws {
+        // Due to different keyboard input listener events (i.e. autocorrection or hardware keyboard connection)
+        // characters after the first one are often skipped, so we'll input it with lower typing frequency
+        let firstCharacter = String(text.prefix(Constants.slowInputCharactersCount))
+        logger.info("first character: \(firstCharacter)")
+        var eventPath = PointerEventPath.pathForTextInput()
+        eventPath.type(text: firstCharacter, typingSpeed: 1)
+        let eventRecord = EventRecord(orientation: .portrait)
+        _ = eventRecord.add(eventPath)
+        try await RunnerDaemonProxy().synthesize(eventRecord: eventRecord)
+
+        // Wait 500ms before dispatching next input text request to avoid iOS dropping characters
+        try await Task.sleep(nanoseconds: UInt64(1_000_000_000 * 0.5))
+
+        if text.count > Constants.slowInputCharactersCount {
+            let remainingText = String(text.suffix(text.count - Constants.slowInputCharactersCount))
+            logger.info("remaining text: \(remainingText)")
+            var eventPath2 = PointerEventPath.pathForTextInput()
+            eventPath2.type(text: remainingText, typingSpeed: Constants.typingFrequency)
+            let eventRecord2 = EventRecord(orientation: .portrait)
+            _ = eventRecord2.add(eventPath2)
+            try await RunnerDaemonProxy().synthesize(eventRecord: eventRecord2)
+        }
+    }
+
+    /// Repeatedly executes a block until it returns `true` or the timeout expires.
+    ///
+    /// - Parameters:
+    ///   - timeout: Maximum time to wait in seconds.
+    ///   - delta: Interval between checks in seconds.
+    ///   - block: Closure that returns `true` when the condition is met.
+    /// - Throws: Error if delta is negative or if the task sleep fails.
+    func repeatUntil(timeout: TimeInterval, delta: TimeInterval, block: () -> Bool) async throws {
+        guard delta >= 0 else {
+            throw NSError(domain: "Invalid value", code: 1, userInfo: [NSLocalizedDescriptionKey: "Delta cannot be negative"])
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            do {
+                try await Task.sleep(nanoseconds: UInt64(1_000_000_000 * delta))
+            } catch {
+                throw NSError(domain: "Failed to sleep task", code: 2, userInfo: [NSLocalizedDescriptionKey: "Task could not be put to sleep"])
+            }
+
+            if block() {
+                break
+            }
+        }
+    }
+}

--- a/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
+++ b/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
@@ -32,6 +32,7 @@ final class JSONRPCDispatcher {
     init() {
         registerHandler(IOTapMethodHandler())
         registerHandler(DumpUIMethodHandler())
+        registerHandler(IOTextMethodHandler())
     }
 
     /// Registers a method handler.

--- a/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
+++ b/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
@@ -9,7 +9,7 @@ import os
 /// incoming requests by looking up and invoking the corresponding handler.
 ///
 /// ## Supported Methods
-/// - `tap`: Performs tap/long-press gestures
+/// - `io_tap`: Performs tap/long-press gestures
 /// - `dump_ui`: Captures UI view hierarchy
 ///
 /// ## Usage
@@ -30,7 +30,7 @@ final class JSONRPCDispatcher {
 
     /// Initializes the dispatcher with default method handlers.
     init() {
-        registerHandler(TapMethodHandler())
+        registerHandler(IOTapMethodHandler())
         registerHandler(DumpUIMethodHandler())
     }
 

--- a/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
+++ b/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
@@ -10,7 +10,7 @@ import os
 ///
 /// ## Supported Methods
 /// - `tap`: Performs tap/long-press gestures
-/// - `dumpUI`: Captures UI view hierarchy
+/// - `dump_ui`: Captures UI view hierarchy
 ///
 /// ## Usage
 /// ```swift

--- a/devicekit-iosUITests/JSONRPC/JSONRPCModels.swift
+++ b/devicekit-iosUITests/JSONRPC/JSONRPCModels.swift
@@ -45,7 +45,7 @@ enum JSONRPCId: Codable, Equatable {
 /// ```json
 /// {
 ///   "jsonrpc": "2.0",
-///   "method": "tap",
+///   "method": "io_tap",
 ///   "params": {"x": 100.0, "y": 200.0},
 ///   "id": 1
 /// }

--- a/devicekit-iosUITests/JSONRPC/XCTestWebSocketServer.swift
+++ b/devicekit-iosUITests/JSONRPC/XCTestWebSocketServer.swift
@@ -30,11 +30,11 @@ extension String {
 ///
 /// ## JSON-RPC Methods
 ///
-/// ### tap
+/// ### io_tap
 /// Performs a tap or long-press at specified coordinates.
 /// ```json
 /// // Request
-/// {"jsonrpc": "2.0", "method": "tap", "params": {"x": 100.0, "y": 200.0}, "id": 1}
+/// {"jsonrpc": "2.0", "method": "io_tap", "params": {"x": 100.0, "y": 200.0}, "id": 1}
 ///
 /// // Response
 /// {"jsonrpc": "2.0", "result": {"success": true}, "id": 1}
@@ -56,7 +56,7 @@ extension String {
 /// ws.onopen = () => {
 ///     ws.send(JSON.stringify({
 ///         jsonrpc: '2.0',
-///         method: 'tap',
+///         method: 'io_tap',
 ///         params: { x: 100, y: 200 },
 ///         id: 1
 ///     }));

--- a/devicekit-iosUITests/JSONRPC/XCTestWebSocketServer.swift
+++ b/devicekit-iosUITests/JSONRPC/XCTestWebSocketServer.swift
@@ -40,11 +40,11 @@ extension String {
 /// {"jsonrpc": "2.0", "result": {"success": true}, "id": 1}
 /// ```
 ///
-/// ### dumpUI
+/// ### dump_ui
 /// Returns the complete view hierarchy.
 /// ```json
 /// // Request
-/// {"jsonrpc": "2.0", "method": "dumpUI", "params": {"appIds": [], "excludeKeyboardElements": false}, "id": 2}
+/// {"jsonrpc": "2.0", "method": "dump_ui", "params": {"appIds": [], "excludeKeyboardElements": false}, "id": 2}
 ///
 /// // Response
 /// {"jsonrpc": "2.0", "result": {"axElement": {...}, "depth": 15}, "id": 2}

--- a/devicekit-iosUITests/XCTest/AXElement.swift
+++ b/devicekit-iosUITests/XCTest/AXElement.swift
@@ -3,7 +3,7 @@ import XCTest
 
 // MARK: - Response Models
 
-/// Response wrapper for the `/dumpUI` endpoint.
+/// Response wrapper for the `/dump_ui` endpoint.
 ///
 /// Contains the root accessibility element and the maximum depth of the tree.
 ///

--- a/devicekit-iosUITests/XCTest/PointerEventPath.swift
+++ b/devicekit-iosUITests/XCTest/PointerEventPath.swift
@@ -27,17 +27,41 @@ struct PointerEventPath {
     ///   - offset: Initial time offset in seconds.
     /// - Returns: A new pointer event path.
     static func pathForTouch(at point: CGPoint, offset: TimeInterval = 0)
-        -> Self
+    -> Self
     {
         let alloced =
-            objc_lookUpClass("XCPointerEventPath")!.alloc() as! NSObject
+        objc_lookUpClass("XCPointerEventPath")!.alloc() as! NSObject
         let selector = NSSelectorFromString("initForTouchAtPoint:offset:")
         let imp = alloced.method(for: selector)
         typealias Method =
-            @convention(c) (NSObject, Selector, CGPoint, TimeInterval) ->
-            NSObject
+        @convention(c) (NSObject, Selector, CGPoint, TimeInterval) ->
+        NSObject
         let method = unsafeBitCast(imp, to: Method.self)
         let path = method(alloced, selector, point, offset)
+        return Self(path: path, offset: offset)
+    }
+
+    /// Creates a pointer event path configured for text input.
+    ///
+    /// This initializes an `XCPointerEventPath` using the private `initForTextInput`
+    /// selector, which prepares the path for keyboard event synthesis rather than
+    /// touch events.
+    ///
+    /// - Parameter offset: Initial time offset in seconds (default: 0).
+    /// - Returns: A new pointer event path configured for text input.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// var textPath = PointerEventPath.pathForTextInput()
+    /// textPath.type(text: "Hello", typingSpeed: 30)
+    /// ```
+    static func pathForTextInput(offset: TimeInterval = 0) -> Self {
+        let alloced = objc_lookUpClass("XCPointerEventPath")!.alloc() as! NSObject
+        let selector = NSSelectorFromString("initForTextInput")
+        let imp = alloced.method(for: selector)
+        typealias Method = @convention(c) (NSObject, Selector) -> NSObject
+        let method = unsafeBitCast(imp, to: Method.self)
+        let path = method(alloced, selector)
         return Self(path: path, offset: offset)
     }
 
@@ -59,8 +83,37 @@ struct PointerEventPath {
         let selector = NSSelectorFromString("liftUpAtOffset:")
         let imp = path.method(for: selector)
         typealias Method =
-            @convention(c) (NSObject, Selector, TimeInterval) -> Void
+        @convention(c) (NSObject, Selector, TimeInterval) -> Void
         let method = unsafeBitCast(imp, to: Method.self)
         method(path, selector, offset)
+    }
+
+    /// Synthesizes keyboard events to type the specified text.
+    ///
+    /// Uses XCTest's private `typeText:atOffset:typingSpeed:shouldRedact:` API
+    /// to generate authentic keyboard input events.
+    ///
+    /// - Parameters:
+    ///   - text: The text string to type.
+    ///   - typingSpeed: Characters per second. Higher values type faster but may
+    ///     cause iOS to drop characters. Recommended: 1 for first character, 30 for rest.
+    ///   - shouldRedact: If `true`, redacts the text in logs/traces for sensitive input.
+    ///
+    /// ## Typing Speed Guidelines
+    /// - Speed 1: Very slow, most reliable for initial character
+    /// - Speed 30: Normal typing speed, good balance of speed and reliability
+    /// - Speed 60+: Fast, may cause character drops on some devices
+    ///
+    /// ## Example
+    /// ```swift
+    /// var path = PointerEventPath.pathForTextInput()
+    /// path.type(text: "password123", typingSpeed: 30, shouldRedact: true)
+    /// ```
+    mutating func type(text: String, typingSpeed: Int, shouldRedact: Bool = false) {
+        let selector = NSSelectorFromString("typeText:atOffset:typingSpeed:shouldRedact:")
+        let imp = path.method(for: selector)
+        typealias Method = @convention(c) (NSObject, Selector, NSString, TimeInterval, UInt64, Bool) -> ()
+        let method = unsafeBitCast(imp, to: Method.self)
+        method(path, selector, text as NSString, offset, UInt64(typingSpeed), shouldRedact)
     }
 }


### PR DESCRIPTION
allow to enter text when a text field is in focus.

For testing WS:

```
victorkachalov@Victors-MacBook-Pro ~ % websocat ws://127.0.0.1:12004/rpc
{"jsonrpc":"2.0","method":"io_text","params":{"text":"Hello, World!","deviceId": "f"},"id":1}
```
expect:
```
{"jsonrpc":"2.0","id":1,"result":{"success":true}}
```

For testing with curl:
```
victorkachalov@Victors-MacBook-Pro devicekit-ios %   curl -X POST http://127.0.0.1:12004/rpc \
    -H "Content-Type: application/json" \
    -d '{
      "jsonrpc": "2.0",
      "method": "io_text",
      "params": {
        "text": "test@example.com", 
        "deviceId": "dd"
      },
      "id": 2
    }'
```
expect:
```
{"jsonrpc":"2.0","id":2,"result":{"success":true}}%
```