### PR TITLE
feat: add apps_launch handler

### DIFF
--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		612DE414298426EF003C2BE0 /* EventRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612DE413298426EF003C2BE0 /* EventRecord.swift */; };
 		613E87D7299A64BD00FF8551 /* PointerEventPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E87D6299A64BD00FF8551 /* PointerEventPath.swift */; };
 		78147F0F2F27AA6B00E61E3B /* IOText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147F0E2F27AA6B00E61E3B /* IOText.swift */; };
+		78147F3D2F27BDBC00E61E3B /* AppsLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */; };
 		787C47972F227F6B0027A012 /* JSONRPCModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47932F227F6B0027A012 /* JSONRPCModels.swift */; };
 		787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47942F227F6B0027A012 /* RPCMethodHandler.swift */; };
 		787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */; };
@@ -237,6 +238,7 @@
 		612DE413298426EF003C2BE0 /* EventRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventRecord.swift; sourceTree = "<group>"; };
 		613E87D6299A64BD00FF8551 /* PointerEventPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointerEventPath.swift; sourceTree = "<group>"; };
 		78147F0E2F27AA6B00E61E3B /* IOText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOText.swift; sourceTree = "<group>"; };
+		78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsLaunch.swift; sourceTree = "<group>"; };
 		787C47922F227F6B0027A012 /* JSONRPCDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCDispatcher.swift; sourceTree = "<group>"; };
 		787C47932F227F6B0027A012 /* JSONRPCModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCModels.swift; sourceTree = "<group>"; };
 		787C47942F227F6B0027A012 /* RPCMethodHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCMethodHandler.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 		787C47DE2F228B770027A012 /* Handlers */ = {
 			isa = PBXGroup;
 			children = (
+				78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */,
 				78147F0E2F27AA6B00E61E3B /* IOText.swift */,
 				787C47DC2F228B770027A012 /* DumpUI.swift */,
 				787C47DD2F228B770027A012 /* IOTap.swift */,
@@ -790,6 +793,7 @@
 				52D8FAAC2D6DD3A20015FAB3 /* FBLogger.m in Sources */,
 				521C1F072D8017480024EE42 /* AXClientProxy.m in Sources */,
 				5261117A2DE5E8E7007C356B /* XCAXClient_iOS+FBSnapshotReqParams.m in Sources */,
+				78147F3D2F27BDBC00E61E3B /* AppsLaunch.swift in Sources */,
 				610D58FB2A49E3CA00B4BBEB /* AXClientSwizzler.swift in Sources */,
 				787C47DF2F228B770027A012 /* IOTap.swift in Sources */,
 				787C47E02F228B770027A012 /* DumpUI.swift in Sources */,

--- a/devicekit-iosUITests/JSONRPC/Handlers/AppsLaunch.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/AppsLaunch.swift
@@ -1,0 +1,93 @@
+import os
+
+struct AppsLaunchRequest : Codable {
+    /// The app's to launch bundle id
+    let bundleId: String
+
+    /// Reserved for future use. Pass an empty array.
+    let deviceId: String
+}
+
+// MARK: - Handler
+
+/// JSON-RPC method handler for app launch operations.
+///
+/// This handler executes app launch based on the provide bundle id.
+/// It uses XCTest's  APIs to activate the desired app
+///
+/// ## Method Name
+/// `apps_launch
+///
+/// ## Response
+/// ```json
+/// {
+///   "jsonrpc": "2.0",
+///   "result": { "success": true },
+///   "id": 1
+/// }
+/// ```
+///
+///## Example Request
+/// ```json
+/// {
+///   "jsonrpc": "2.0",
+///   "method": "apps_launch",
+///   "params": {
+///     "bundleId": "com.apple.mobilesafari",
+///     "deviceId": "your_device_id"
+///   },
+///   "id": 1
+/// }
+///
+/// ## Errors
+/// - `-32602`: Invalid parameters (missing or malformed request)
+/// - `-32603`: Internal error (app is not installed)
+@MainActor
+struct ApsLaunchMethodHandler: RPCMethodHandler {
+
+    /// The JSON-RPC method name this handler responds to.
+    static let methodName = "apps_launch"
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: Self.self)
+    )
+
+    /// Executes the app launch operation.
+    ///
+    /// - Parameter params: JSON-RPC parameters containing the bundle id to launch.
+    /// - Returns: A JSON object with `success: true` on successful input.
+    /// - Throws: `RPCMethodError.invalidParams` if parameters are invalid,
+    ///           `RPCMethodError.internalError` if apps launch fails.
+    func execute(params: JSONValue?) async throws -> JSONValue {
+        guard let params = params else {
+            throw RPCMethodError.invalidParams("Missing parameters for apps_launch method")
+        }
+
+        let paramsData: Data
+        do {
+            paramsData = try params.toData()
+        } catch {
+            throw RPCMethodError.invalidParams("Failed to serialize params: \(error.localizedDescription)")
+        }
+
+        let request: AppsLaunchRequest
+        do {
+            request = try JSONDecoder().decode(AppsLaunchRequest.self, from: paramsData)
+        } catch {
+            throw RPCMethodError.invalidParams("Invalid apps_launch parameters: \(error.localizedDescription)")
+        }
+
+        let start = Date()
+
+        logger.info("[Start] Launching app with bundle ID: \(request.bundleId)")
+        XCUIApplication(bundleIdentifier: request.bundleId).activate()
+        logger.info("[Done] Launching app with bundle ID: \(request.bundleId)")
+
+        let duration = Date().timeIntervalSince(start)
+        logger.info("Launch App duration took \(duration)")
+        return .object(["success": .bool(true)])
+    }
+
+}
+

--- a/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
+++ b/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
@@ -33,6 +33,7 @@ final class JSONRPCDispatcher {
         registerHandler(IOTapMethodHandler())
         registerHandler(DumpUIMethodHandler())
         registerHandler(IOTextMethodHandler())
+        registerHandler(ApsLaunchMethodHandler())
     }
 
     /// Registers a method handler.


### PR DESCRIPTION
test with curl:

```
victorkachalov@Victors-MacBook-Pro devicekit-ios %   curl -X POST http://127.0.0.1:12004/rpc \
    -H "Content-Type: application/json" \
    -d '{
      "jsonrpc": "2.0",
      "method": "apps_launch",
      "params": {
        "bundleId": "com.apple.mobilesafari", "deviceId": "dd"
      },
      "id": 2
    }'
```

test with ws:
```
victorkachalov@Victors-MacBook-Pro ~ % websocat ws://127.0.0.1:12004/rpc
{"jsonrpc": "2.0", "method": "apps_launch", "params": { "bundleId": "com.apple.mobilesafari", "deviceId": "dd" }, "id": 2 }
```