### PR TITLE
feat: add io_swipe

### DIFF
--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		613E87D7299A64BD00FF8551 /* PointerEventPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E87D6299A64BD00FF8551 /* PointerEventPath.swift */; };
 		78147F0F2F27AA6B00E61E3B /* IOText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147F0E2F27AA6B00E61E3B /* IOText.swift */; };
 		78147F3D2F27BDBC00E61E3B /* AppsLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */; };
+		78147FCB2F27C04400E61E3B /* IOSwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147FCA2F27C03500E61E3B /* IOSwipe.swift */; };
 		787C47972F227F6B0027A012 /* JSONRPCModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47932F227F6B0027A012 /* JSONRPCModels.swift */; };
 		787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47942F227F6B0027A012 /* RPCMethodHandler.swift */; };
 		787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */; };
@@ -239,6 +240,7 @@
 		613E87D6299A64BD00FF8551 /* PointerEventPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointerEventPath.swift; sourceTree = "<group>"; };
 		78147F0E2F27AA6B00E61E3B /* IOText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOText.swift; sourceTree = "<group>"; };
 		78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsLaunch.swift; sourceTree = "<group>"; };
+		78147FCA2F27C03500E61E3B /* IOSwipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSwipe.swift; sourceTree = "<group>"; };
 		787C47922F227F6B0027A012 /* JSONRPCDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCDispatcher.swift; sourceTree = "<group>"; };
 		787C47932F227F6B0027A012 /* JSONRPCModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCModels.swift; sourceTree = "<group>"; };
 		787C47942F227F6B0027A012 /* RPCMethodHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCMethodHandler.swift; sourceTree = "<group>"; };
@@ -557,6 +559,7 @@
 		787C47DE2F228B770027A012 /* Handlers */ = {
 			isa = PBXGroup;
 			children = (
+				78147FCA2F27C03500E61E3B /* IOSwipe.swift */,
 				78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */,
 				78147F0E2F27AA6B00E61E3B /* IOText.swift */,
 				787C47DC2F228B770027A012 /* DumpUI.swift */,
@@ -799,6 +802,7 @@
 				787C47E02F228B770027A012 /* DumpUI.swift in Sources */,
 				521C1F102D8051FC0024EE42 /* XCTestDaemonsProxy.m in Sources */,
 				613E87D7299A64BD00FF8551 /* PointerEventPath.swift in Sources */,
+				78147FCB2F27C04400E61E3B /* IOSwipe.swift in Sources */,
 				787C48482F228D960027A012 /* JSONRPCMessageHandler.swift in Sources */,
 				9811C9092C49751D00DDACA0 /* OrientationGeometry.swift in Sources */,
 				612DE414298426EF003C2BE0 /* EventRecord.swift in Sources */,

--- a/devicekit-iosUITests/JSONRPC/Handlers/IOSwipe.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/IOSwipe.swift
@@ -1,0 +1,149 @@
+import os
+
+/// Configuration constants for swipe gesture behavior.
+private enum Constants {
+    /// Default duration (in seconds) for a synthesized swipe gesture.
+    /// A short delay helps avoid dropped events when interacting with
+    /// system-level gesture recognizers.
+    static let defaultSwipeDuration = 0.1
+}
+
+/// A JSON‑RPC request describing a swipe gesture to perform on an iOS device.
+///
+/// The request contains the device identifier and the start/end coordinates
+/// of the swipe in screen space.
+struct IOSwipeRequest: Decodable {
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId, x1, y1, x2, y2
+    }
+
+    /// The target device identifier.
+    let deviceId: String
+
+    /// Starting X coordinate of the swipe.
+    let x1: Int
+
+    /// Starting Y coordinate of the swipe.
+    let y1: Int
+
+    /// Ending X coordinate of the swipe.
+    let x2: Int
+
+    /// Ending Y coordinate of the swipe.
+    let y2: Int
+
+    /// Creates a swipe request with explicit parameters.
+    init(deviceId: String, x1: Int, y1: Int, x2: Int, y2: Int) {
+        self.deviceId = deviceId
+        self.x1 = x1
+        self.y1 = y1
+        self.x2 = x2
+        self.y2 = y2
+    }
+
+    /// Decodes the request from a JSON‑RPC payload.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deviceId = try container.decode(String.self, forKey: .deviceId)
+        x1 = try container.decode(Int.self, forKey: .x1)
+        y1 = try container.decode(Int.self, forKey: .y1)
+        x2 = try container.decode(Int.self, forKey: .x2)
+        y2 = try container.decode(Int.self, forKey: .y2)
+    }
+}
+
+/// JSON‑RPC method handler for performing swipe gestures on an iOS device.
+///
+/// This handler decodes the incoming parameters, constructs a synthesized
+/// swipe event using private XCTest SPI, and forwards it to the
+/// `RunnerDaemonProxy` for execution.
+///
+/* Example usage with `curl`
+ curl -X POST http://127.0.0.1:12004/rpc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "io_swipe",
+    "params": {
+      "deviceId": "dd",
+      "x1": 0,
+      "y1": 0,
+      "x2": 0,
+      "y2": 700
+    },
+    "id": 42
+  }'
+ */
+///
+/* Example usage with ws
+ {"jsonrpc": "2.0", "method": "io_swipe", "params": { "deviceId": "dd", "x1": 0, "y1": 0, "x2": 0, "y2": 700 }, "id": 42 }
+ */
+///
+@MainActor
+struct IOSwipeMethodHandler: RPCMethodHandler {
+
+    /// The JSON‑RPC method name exposed by this handler.
+    static let methodName = "io_swipe"
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: Self.self)
+    )
+
+    /// Executes the `io_swipe` JSON‑RPC method.
+    ///
+    /// - Parameter params: The JSON‑RPC parameters containing swipe coordinates.
+    /// - Returns: A JSON object `{ "success": true }` on success.
+    /// - Throws: `RPCMethodError` if decoding fails or the gesture cannot be synthesized.
+    func execute(params: JSONValue?) async throws -> JSONValue {
+        guard let params = params else {
+            throw RPCMethodError.invalidParams("Missing parameters for io_swipe method")
+        }
+
+        let paramsData: Data
+        do {
+            paramsData = try params.toData()
+        } catch {
+            throw RPCMethodError.invalidParams("Failed to serialize params: \(error.localizedDescription)")
+        }
+
+        let request: IOSwipeRequest
+        do {
+            request = try JSONDecoder().decode(IOSwipeRequest.self, from: paramsData)
+        } catch {
+            throw RPCMethodError.invalidParams("Invalid io_swipe parameters: \(error.localizedDescription)")
+        }
+
+        do {
+            try await swipePrivateAPI(
+                start: CGPoint(x: request.x1, y: request.y1),
+                end: CGPoint(x: request.x2, y: request.y2),
+                duration: Constants.defaultSwipeDuration
+            )
+
+            return .object(["success": .bool(true)])
+        } catch {
+            logger.error("Error performing swipe: \(error)")
+            throw RPCMethodError.internalError("Error performing swipe: \(error.localizedDescription)")
+        }
+    }
+
+    /// Synthesizes a swipe gesture using private XCTest APIs.
+    ///
+    /// - Parameters:
+    ///   - start: The starting point of the swipe.
+    ///   - end: The ending point of the swipe.
+    ///   - duration: Duration of the gesture in seconds.
+    ///
+    /// This uses `EventRecord` and `RunnerDaemonProxy` to send the gesture
+    /// to the XCTest runner daemon.
+    func swipePrivateAPI(start: CGPoint, end: CGPoint, duration: Double) async throws {
+        logger.info("Swipe (v1) from \(start.debugDescription) to \(end.debugDescription) with duration \(duration)")
+
+        let eventRecord = EventRecord(orientation: .portrait)
+        _ = eventRecord.addSwipeEvent(start: start, end: end, duration: duration)
+
+        try await RunnerDaemonProxy().synthesize(eventRecord: eventRecord)
+    }
+}

--- a/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
+++ b/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
@@ -34,6 +34,7 @@ final class JSONRPCDispatcher {
         registerHandler(DumpUIMethodHandler())
         registerHandler(IOTextMethodHandler())
         registerHandler(ApsLaunchMethodHandler())
+        registerHandler(IOSwipeMethodHandler())
     }
 
     /// Registers a method handler.

--- a/devicekit-iosUITests/XCTest/EventRecord.swift
+++ b/devicekit-iosUITests/XCTest/EventRecord.swift
@@ -70,6 +70,35 @@ final class EventRecord: NSObject {
         return add(path)
     }
 
+    /// Adds a synthesized swipe gesture to the event record.
+    ///
+    /// This method constructs a `PointerEventPath` beginning at the specified
+    /// starting coordinate, applies a short initial delay to mimic a natural
+    /// finger‑down contact, moves the touch to the ending coordinate over the
+    /// specified duration, and finally lifts the finger to complete the gesture.
+    ///
+    /// The resulting path is appended to the event record and returned.
+    ///
+    /// - Parameters:
+    ///   - start: The starting point of the swipe in screen coordinates.
+    ///   - end: The ending point of the swipe in screen coordinates.
+    ///   - duration: The duration of the swipe movement, excluding the initial
+    ///               tap‑down delay.
+    /// - Returns: The updated event record containing the synthesized swipe path.
+    ///
+    /// - Note:
+    ///   The gesture includes an implicit `defaultTapDuration` delay after the
+    ///   initial touch‑down to ensure compatibility with system gesture recognizers
+    ///   and to avoid dropped events on real devices.
+    func addSwipeEvent(start: CGPoint, end: CGPoint, duration: TimeInterval) -> Self {
+        var path = PointerEventPath.pathForTouch(at: start)
+        path.offset += Self.defaultTapDuration
+        path.moveTo(point: end)
+        path.offset += duration
+        path.liftUp()
+        return add(path)
+    }
+
     /// Adds a pointer event path to this event record.
     ///
     /// - Parameter path: The pointer event path to add.

--- a/devicekit-iosUITests/XCTest/PointerEventPath.swift
+++ b/devicekit-iosUITests/XCTest/PointerEventPath.swift
@@ -88,6 +88,31 @@ struct PointerEventPath {
         method(path, selector, offset)
     }
 
+    /// Moves the active touch in the pointer event path to a new screen coordinate.
+    ///
+    /// This method dynamically invokes the private XCTest selector
+    /// `moveToPoint:atOffset:` on the underlying `PointerEventPath` instance.
+    /// The selector updates the touch location at the current gesture time offset,
+    /// effectively extending the gesture with a movement segment.
+    ///
+    /// Because the selector is not exposed in Swift, the implementation retrieves
+    /// the Objective‑C method IMP at runtime and bridges it to a callable function
+    /// using `unsafeBitCast`.
+    ///
+    /// - Parameter point: The new touch location in screen coordinates.
+    ///
+    /// - Note:
+    ///   The movement occurs at the current `offset` value, which represents the
+    ///   accumulated gesture time. Callers are responsible for adjusting `offset`
+    ///   before invoking this method to control the timing of the gesture.
+    mutating func moveTo(point: CGPoint) {
+        let selector = NSSelectorFromString("moveToPoint:atOffset:")
+        let imp = path.method(for: selector)
+        typealias Method = @convention(c) (NSObject, Selector, CGPoint, TimeInterval) -> ()
+        let method = unsafeBitCast(imp, to: Method.self)
+        method(path, selector, point, offset)
+    }
+
     /// Synthesizes keyboard events to type the specified text.
     ///
     /// Uses XCTest's private `typeText:atOffset:typingSpeed:shouldRedact:` API


### PR DESCRIPTION

Example usage with `curl`
```
 curl -X POST http://127.0.0.1:12004/rpc \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "method": "io_swipe",
    "params": {
      "deviceId": "dd",
      "x1": 0,
      "y1": 0,
      "x2": 0,
      "y2": 700
    },
    "id": 42
  }'
```

Example usage with ws
```
 {"jsonrpc": "2.0", "method": "io_swipe", "params": { "deviceId": "dd", "x1": 0, "y1": 0, "x2": 0, "y2": 700 }, "id": 42 }

```