### PR TITLE
feat: add io_longpress

### DIFF
--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		78147F0F2F27AA6B00E61E3B /* IOText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147F0E2F27AA6B00E61E3B /* IOText.swift */; };
 		78147F3D2F27BDBC00E61E3B /* AppsLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */; };
 		78147FCB2F27C04400E61E3B /* IOSwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78147FCA2F27C03500E61E3B /* IOSwipe.swift */; };
+		7814800B2F27C56100E61E3B /* IOLongpress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7814800A2F27C55500E61E3B /* IOLongpress.swift */; };
 		787C47972F227F6B0027A012 /* JSONRPCModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47932F227F6B0027A012 /* JSONRPCModels.swift */; };
 		787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47942F227F6B0027A012 /* RPCMethodHandler.swift */; };
 		787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */; };
@@ -241,6 +242,7 @@
 		78147F0E2F27AA6B00E61E3B /* IOText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOText.swift; sourceTree = "<group>"; };
 		78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsLaunch.swift; sourceTree = "<group>"; };
 		78147FCA2F27C03500E61E3B /* IOSwipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSwipe.swift; sourceTree = "<group>"; };
+		7814800A2F27C55500E61E3B /* IOLongpress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOLongpress.swift; sourceTree = "<group>"; };
 		787C47922F227F6B0027A012 /* JSONRPCDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCDispatcher.swift; sourceTree = "<group>"; };
 		787C47932F227F6B0027A012 /* JSONRPCModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCModels.swift; sourceTree = "<group>"; };
 		787C47942F227F6B0027A012 /* RPCMethodHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCMethodHandler.swift; sourceTree = "<group>"; };
@@ -559,6 +561,7 @@
 		787C47DE2F228B770027A012 /* Handlers */ = {
 			isa = PBXGroup;
 			children = (
+				7814800A2F27C55500E61E3B /* IOLongpress.swift */,
 				78147FCA2F27C03500E61E3B /* IOSwipe.swift */,
 				78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */,
 				78147F0E2F27AA6B00E61E3B /* IOText.swift */,
@@ -808,6 +811,7 @@
 				612DE414298426EF003C2BE0 /* EventRecord.swift in Sources */,
 				787C47972F227F6B0027A012 /* JSONRPCModels.swift in Sources */,
 				787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */,
+				7814800B2F27C56100E61E3B /* IOLongpress.swift in Sources */,
 				787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */,
 				787C479A2F227F6B0027A012 /* JSONRPCDispatcher.swift in Sources */,
 				521C1F0B2D801A360024EE42 /* XCUIApplication+Helper.m in Sources */,

--- a/devicekit-iosUITests/JSONRPC/Handlers/IOLongpress.swift
+++ b/devicekit-iosUITests/JSONRPC/Handlers/IOLongpress.swift
@@ -2,9 +2,9 @@ import os
 
 // MARK: - Tap Request Model
 
-/// Request body for the `/io_tap` endpoint.
+/// Request body for the `/io_longpress` endpoint.
 ///
-/// This model represents the JSON payload for tap gestures.
+/// This model represents the JSON payload for long-press gestures.
 ///
 /// ## JSON Format
 /// ```json
@@ -15,27 +15,32 @@ import os
 /// }
 /// ```
 ///
-struct IOTapRequest: Codable {
+struct IOLongpressRequest: Codable {
 
     /// X coordinate in screen points.
     let x: Float
 
     /// Y coordinate in screen points.
     let y: Float
+
+    /// Duration in seconds for long-press gestures.
+    /// - `nil` or omitted: Performs a simple tap.
+    /// - Non-nil value: Performs a long-press for the specified duration.
+    let duration: TimeInterval
 }
 
 // MARK: - Tap Method Handler
 
-/// JSON-RPC handler for the `io_tap` method.
+/// JSON-RPC handler for the `io_longpress` method.
 ///
 /// Performs tap or long-press gestures at screen coordinates.
 ///
 /// ## Parameters
 /// ```json
 /// {
-///   "x": 100.0,
-///   "y": 200.0,
-///   "duration": null
+///   "x": 100,
+///   "y": 200,
+///   "duration": 2
 /// }
 /// ```
 ///
@@ -44,17 +49,17 @@ struct IOTapRequest: Codable {
 /// {"success": true}
 /// ```
 @MainActor
-struct IOTapMethodHandler: RPCMethodHandler {
-    static let methodName = "io_tap"
+struct IOLongpressMethodHandler: RPCMethodHandler {
+    static let methodName = "io_longpress"
 
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!,
         category: String(describing: Self.self)
     )
 
-    /// Executes the `io_tap` JSON‑RPC method.
+    /// Executes the `io_longpress` JSON‑RPC method.
     ///
-    /// - Parameter params: The JSON‑RPC parameters containing tap coordinates.
+    /// - Parameter params: The JSON‑RPC parameters containing longpress coordinates and duration.
     /// - Returns: A JSON object `{ "success": true }` on success.
     /// - Throws: `RPCMethodError` if decoding fails or the gesture cannot be synthesized.
     func execute(params: JSONValue?) async throws -> JSONValue {
@@ -69,9 +74,9 @@ struct IOTapMethodHandler: RPCMethodHandler {
             throw RPCMethodError.invalidParams("Failed to serialize params: \(error.localizedDescription)")
         }
 
-        let request: IOTapRequest
+        let request: IOLongpressRequest
         do {
-            request = try JSONDecoder().decode(IOTapRequest.self, from: paramsData)
+            request = try JSONDecoder().decode(IOLongpressRequest.self, from: paramsData)
         } catch {
             throw RPCMethodError.invalidParams("Invalid io_tap parameters: \(error.localizedDescription)")
         }
@@ -84,11 +89,13 @@ struct IOTapMethodHandler: RPCMethodHandler {
         )
         let (x, y) = (point.x, point.y)
 
+        logger.info("Long pressing \(x), \(y) for \(request.duration)s")
+
         do {
             let eventRecord = EventRecord(orientation: .portrait)
             _ = eventRecord.addPointerTouchEvent(
                 at: CGPoint(x: CGFloat(x), y: CGFloat(y)),
-                touchUpAfter: nil
+                touchUpAfter: request.duration
             )
             let start = Date()
             try await RunnerDaemonProxy().synthesize(eventRecord: eventRecord)
@@ -101,4 +108,3 @@ struct IOTapMethodHandler: RPCMethodHandler {
         }
     }
 }
-

--- a/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
+++ b/devicekit-iosUITests/JSONRPC/JSONRPCDispatcher.swift
@@ -35,6 +35,7 @@ final class JSONRPCDispatcher {
         registerHandler(IOTextMethodHandler())
         registerHandler(ApsLaunchMethodHandler())
         registerHandler(IOSwipeMethodHandler())
+        registerHandler(IOLongpressMethodHandler())
     }
 
     /// Registers a method handler.


### PR DESCRIPTION
example with curl:

```
victorkachalov@Victors-MacBook-Pro devicekit-ios % curl -X POST http://localhost:12004/rpc \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"io_longpress","params":{"x":30,"y":510, "duration": 3},"id":2}'
```

example with ws:
```
victorkachalov@Victors-MacBook-Pro ~ % websocat ws://127.0.0.1:12004/rpc
{"jsonrpc":"2.0","method":"io_longpress","params":{"x":30,"y":510, "duration": 3},"id":2}
```