### PR TITLE
feat: add mjpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ DeviceKit iOS is a UI automation and screen streaming framework for iOS devices.
 - [WebSocket Examples](#websocket-examples)
 - [Error Codes](#json-rpc-error-codes)
 - [Screen Streaming](#screen-streaming)
-  - [screencapture.sh](#quick-start-screencapturesh-recommended)
+  - [MJPEG Streaming](#mjpeg-streaming-browser-friendly)
+  - [XCTest H.264 Streaming](#xctest-h264-streaming-http)
+  - [ReplayKit H.264 Streaming](#replaykit-h264-streaming-broadcastextension)
+  - [Streaming Comparison](#streaming-method-comparison)
 - [Building](#building)
 
 ---
@@ -698,7 +701,122 @@ ws.on('message', (data) => {
 
 ## Screen Streaming
 
-### Overview
+DeviceKit iOS provides multiple screen streaming methods:
+
+| Method | Source | Protocol | Port | Endpoint | Use Case |
+|--------|--------|----------|------|----------|----------|
+| **ReplayKit H.264** | BroadcastExtension | TCP | 12005 | N/A | High quality, system-level capture |
+| **XCTest H.264** | Screenshot API | HTTP | 12004 | `/h264` | Video recording, no app required |
+| **MJPEG** | Screenshot API | HTTP | 12004 | `/mjpeg` | Browser viewing, simple clients |
+
+---
+
+### MJPEG Streaming (Browser-friendly)
+
+Motion JPEG streaming over HTTP. Works in browsers and simple HTTP clients.
+
+#### Quick Start
+
+```bash
+# View in browser
+open "http://127.0.0.1:12004/mjpeg"
+
+# View with ffplay
+ffplay -fflags nobuffer "http://127.0.0.1:12004/mjpeg"
+
+# View with VLC
+vlc "http://127.0.0.1:12004/mjpeg"
+```
+
+#### URL Parameters
+
+| Parameter | Default | Range | Description |
+|-----------|---------|-------|-------------|
+| `fps` | 10 | 1-60 | Frames per second |
+| `quality` | 25 | 1-100 | JPEG quality (%) |
+| `scale` | 100 | 10-100 | Image scale (%) |
+
+#### Examples
+
+```bash
+# Higher quality and frame rate
+open "http://127.0.0.1:12004/mjpeg?fps=30&quality=50"
+
+# Lower bandwidth (reduced resolution)
+open "http://127.0.0.1:12004/mjpeg?fps=15&quality=30&scale=50"
+
+# Python OpenCV viewing
+python3 -c "
+import cv2
+cap = cv2.VideoCapture('http://127.0.0.1:12004/mjpeg?fps=15')
+while True:
+    ret, frame = cap.read()
+    if ret:
+        cv2.imshow('iOS Device', frame)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+"
+```
+
+---
+
+### XCTest H.264 Streaming (HTTP)
+
+H.264 streaming over HTTP, similar to MJPEG. No separate TCP port needed.
+
+#### Quick Start
+
+```bash
+# View with ffplay (simplest)
+curl http://127.0.0.1:12004/h264 | ffplay -fflags nobuffer -flags low_delay -f h264 -
+
+# Or with custom settings
+curl "http://127.0.0.1:12004/h264?fps=30&bitrate=4000000&width=960&height=540" | ffplay -f h264 -
+```
+
+#### URL Parameters
+
+| Parameter | Default | Range | Description |
+|-----------|---------|-------|-------------|
+| `fps` | 30 | 1-60 | Frames per second |
+| `bitrate` | 4000000 | 100000-10000000 | Target bitrate (bps) |
+| `quality` | 60 | 1-100 | Encoder quality hint |
+| `width` | 960 | 100-3840 | Output width (pixels) |
+| `height` | 540 | 100-2160 | Output height (pixels) |
+
+#### Examples
+
+```bash
+# Default settings (30fps, 4Mbps, 960x540)
+curl http://127.0.0.1:12004/h264 | ffplay -f h264 -
+
+# High quality, full HD
+curl "http://127.0.0.1:12004/h264?fps=30&bitrate=8000000&width=1920&height=1080" | ffplay -f h264 -
+
+# Low bandwidth
+curl "http://127.0.0.1:12004/h264?fps=15&bitrate=1000000&width=480&height=270" | ffplay -f h264 -
+
+# With ffplay low-latency flags
+curl http://127.0.0.1:12004/h264 | ffplay -fflags nobuffer -flags low_delay -framedrop -f h264 -
+```
+
+#### Recording
+
+```bash
+# Record to MP4
+curl http://127.0.0.1:12004/h264 | ffmpeg -f h264 -i - -c copy recording.mp4
+
+# Record for 60 seconds
+timeout 60 curl http://127.0.0.1:12004/h264 | ffmpeg -f h264 -i - -c copy recording.mp4
+```
+
+---
+
+### ReplayKit H.264 Streaming (BroadcastExtension)
+
+High-quality system-level screen capture using ReplayKit BroadcastExtension. Provides the best quality and performance.
+
+#### Overview
 
 DeviceKit iOS provides real-time H.264 video streaming via TCP on port 12005. The stream is compatible with standard video players and processing pipelines.
 
@@ -811,6 +929,32 @@ gst-launch-1.0 tcpclientsrc -e do-timestamp=true host=$DEVICE_IP port=12005 \
 ```bash
 docker cp <container_id>:/recording.mp4 ./recording.mp4
 ```
+
+---
+
+### Streaming Method Comparison
+
+| Feature | ReplayKit H.264 | XCTest H.264 | MJPEG |
+|---------|-----------------|--------------|-------|
+| **Protocol** | TCP | HTTP | HTTP |
+| **Port** | 12005 | 12004 | 12004 |
+| **Endpoint** | N/A (TCP) | `/h264` | `/mjpeg` |
+| **Requires App** | Yes (ScreenStreamer) | No | No |
+| **Quality** | Excellent | Good | Good |
+| **Latency** | Low | Medium | Low |
+| **Bandwidth** | Low (~2-8 Mbps) | Low (~1-4 Mbps) | High (~10-30 Mbps) |
+| **Browser Support** | No | No | Yes |
+| **Best For** | Production streaming | Video recording | Debugging, browser |
+
+### Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| ffplay shows nothing | Wait 1-2 seconds for keyframe; use `-fflags nobuffer` |
+| High latency | Add `-flags low_delay -framedrop` to ffplay |
+| Connection refused | Check port forwarding: `iproxy <port>:<port>` |
+| Choppy playback | Reduce fps or increase bitrate |
+| MJPEG slow in browser | Reduce `quality` and `scale` parameters |
 
 ---
 

--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -1032,9 +1032,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1048,7 +1048,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1063,9 +1063,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1079,7 +1079,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1093,9 +1093,9 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1103,7 +1103,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-iosUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-iosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1123,9 +1123,9 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1133,7 +1133,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-iosUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-iosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1153,9 +1153,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1183,7 +1183,7 @@
 					"-DOPUS_BUILD",
 					"-DVAR_ARRAYS",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1204,9 +1204,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1234,7 +1234,7 @@
 					"-DOPUS_BUILD",
 					"-DVAR_ARRAYS",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1254,9 +1254,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1271,7 +1271,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1291,9 +1291,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = MAVP5V2N7V;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1308,7 +1308,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;

--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -51,15 +51,22 @@
 		781480752F27D2BB00E61E3B /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781480742F27D2B900E61E3B /* URL.swift */; };
 		781480FF2F27DEE600E61E3B /* IOGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781480FE2F27DEE600E61E3B /* IOGesture.swift */; };
 		7844BCC12F28128A00F7E003 /* OpusCodec in Frameworks */ = {isa = PBXBuildFile; productRef = 7844BCC02F28128A00F7E003 /* OpusCodec */; };
+		785281492F2BEC40002A7531 /* FBScreenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 785281472F2BEC40002A7531 /* FBScreenshot.h */; };
+		7852814A2F2BEC40002A7531 /* FBScreenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 785281482F2BEC40002A7531 /* FBScreenshot.m */; };
 		787C47972F227F6B0027A012 /* JSONRPCModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47932F227F6B0027A012 /* JSONRPCModels.swift */; };
 		787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47942F227F6B0027A012 /* RPCMethodHandler.swift */; };
-		787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */; };
+		787C47992F227F6B0027A012 /* XCTestServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47952F227F6B0027A012 /* XCTestServer.swift */; };
 		787C479A2F227F6B0027A012 /* JSONRPCDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47922F227F6B0027A012 /* JSONRPCDispatcher.swift */; };
 		787C47DF2F228B770027A012 /* IOTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47DD2F228B770027A012 /* IOTap.swift */; };
 		787C47E02F228B770027A012 /* DumpUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C47DC2F228B770027A012 /* DumpUI.swift */; };
 		787C48462F228D8D0027A012 /* JSONRPCHTTPHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C48452F228D8C0027A012 /* JSONRPCHTTPHandler.swift */; };
 		787C48482F228D960027A012 /* JSONRPCMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C48472F228D950027A012 /* JSONRPCMessageHandler.swift */; };
 		787C95982F17F23500AB3BF1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 787C95972F17F23500AB3BF1 /* Assets.xcassets */; };
+		78C54B332F2CF23500A9369C /* TCP in Frameworks */ = {isa = PBXBuildFile; productRef = 78C54B322F2CF23500A9369C /* TCP */; };
+		78C54B352F2CF23800A9369C /* H264Codec in Frameworks */ = {isa = PBXBuildFile; productRef = 78C54B342F2CF23800A9369C /* H264Codec */; };
+		78C54BB32F2D4F3400A9369C /* CPUUsageMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C54BB22F2D4F2F00A9369C /* CPUUsageMonitor.swift */; };
+		78C54BCB2F2D5C4600A9369C /* MemoryUsageMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C54BCA2F2D5C3E00A9369C /* MemoryUsageMonitor.swift */; };
+		78C54BCF2F2D5CAD00A9369C /* MetricsReportGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C54BCE2F2D5CA700A9369C /* MetricsReportGenerator.swift */; };
 		78F689082F17EE190025C8AC /* ReplayKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78F689072F17EE190025C8AC /* ReplayKit.framework */; };
 		78F689122F17EE190025C8AC /* ReplayKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78F689072F17EE190025C8AC /* ReplayKit.framework */; };
 		78F689142F17EE190025C8AC /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78F689132F17EE190025C8AC /* UIKit.framework */; };
@@ -250,15 +257,20 @@
 		781480362F27CEF000E61E3B /* Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screenshot.swift; sourceTree = "<group>"; };
 		781480742F27D2B900E61E3B /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		781480FE2F27DEE600E61E3B /* IOGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOGesture.swift; sourceTree = "<group>"; };
+		785281472F2BEC40002A7531 /* FBScreenshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBScreenshot.h; sourceTree = "<group>"; };
+		785281482F2BEC40002A7531 /* FBScreenshot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBScreenshot.m; sourceTree = "<group>"; };
 		787C47922F227F6B0027A012 /* JSONRPCDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCDispatcher.swift; sourceTree = "<group>"; };
 		787C47932F227F6B0027A012 /* JSONRPCModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCModels.swift; sourceTree = "<group>"; };
 		787C47942F227F6B0027A012 /* RPCMethodHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCMethodHandler.swift; sourceTree = "<group>"; };
-		787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestWebSocketServer.swift; sourceTree = "<group>"; };
+		787C47952F227F6B0027A012 /* XCTestServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestServer.swift; sourceTree = "<group>"; };
 		787C47DC2F228B770027A012 /* DumpUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DumpUI.swift; sourceTree = "<group>"; };
 		787C47DD2F228B770027A012 /* IOTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOTap.swift; sourceTree = "<group>"; };
 		787C48452F228D8C0027A012 /* JSONRPCHTTPHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCHTTPHandler.swift; sourceTree = "<group>"; };
 		787C48472F228D950027A012 /* JSONRPCMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCMessageHandler.swift; sourceTree = "<group>"; };
 		787C95972F17F23500AB3BF1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		78C54BB22F2D4F2F00A9369C /* CPUUsageMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPUUsageMonitor.swift; sourceTree = "<group>"; };
+		78C54BCA2F2D5C3E00A9369C /* MemoryUsageMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUsageMonitor.swift; sourceTree = "<group>"; };
+		78C54BCE2F2D5CA700A9369C /* MetricsReportGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsReportGenerator.swift; sourceTree = "<group>"; };
 		78F689062F17EE190025C8AC /* BroadcastUploadExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BroadcastUploadExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F689072F17EE190025C8AC /* ReplayKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReplayKit.framework; path = System/Library/Frameworks/ReplayKit.framework; sourceTree = SDKROOT; };
 		78F689112F17EE190025C8AC /* BroadcastUploadExtensionSetupUI.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BroadcastUploadExtensionSetupUI.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -287,6 +299,7 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		787C95D52F17F59E00AB3BF1 /* View */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = View; sourceTree = "<group>"; };
+		78C54BD12F2D67E300A9369C /* Streamer */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Streamer; sourceTree = "<group>"; };
 		78F689092F17EE190025C8AC /* BroadcastUploadExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (78F6891F2F17EE190025C8AC /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BroadcastUploadExtension; sourceTree = "<group>"; };
 		78F689152F17EE190025C8AC /* BroadcastUploadExtensionSetupUI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (78F689232F17EE190025C8AC /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BroadcastUploadExtensionSetupUI; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -303,8 +316,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78C54B332F2CF23500A9369C /* TCP in Frameworks */,
 				612DE40229801F71003C2BE0 /* XCTest.framework in Frameworks */,
 				5279BFD62935ECE20056C609 /* FlyingFox in Frameworks */,
+				78C54B352F2CF23800A9369C /* H264Codec in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -367,11 +382,16 @@
 		52049BF6293503A200807AA3 /* devicekit-iosUITests */ = {
 			isa = PBXGroup;
 			children = (
+				78C54BD12F2D67E300A9369C /* Streamer */,
+				78C54BCE2F2D5CA700A9369C /* MetricsReportGenerator.swift */,
+				78C54BCA2F2D5C3E00A9369C /* MemoryUsageMonitor.swift */,
+				78C54BB22F2D4F2F00A9369C /* CPUUsageMonitor.swift */,
 				787C47962F227F6B0027A012 /* JSONRPC */,
 				612DE410298410F9003C2BE0 /* XCTest */,
 				52D8FAA92D6DD3850015FAB3 /* Utilities */,
 				52D8FA8E2D6DCF010015FAB3 /* Categories */,
 				52D8F8F12D6DCC150015FAB3 /* PrivateHeaders */,
+				787C47952F227F6B0027A012 /* XCTestServer.swift */,
 				52049BF7293503A200807AA3 /* devicekit_iosUITests.swift */,
 			);
 			path = "devicekit-iosUITests";
@@ -524,6 +544,8 @@
 		52D8FAA92D6DD3850015FAB3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				785281472F2BEC40002A7531 /* FBScreenshot.h */,
+				785281482F2BEC40002A7531 /* FBScreenshot.m */,
 				521C1F0F2D8051F20024EE42 /* XCTestDaemonsProxy.m */,
 				521C1F0D2D8051890024EE42 /* XCTestDaemonsProxy.h */,
 				521C1F062D8017460024EE42 /* AXClientProxy.m */,
@@ -561,7 +583,6 @@
 				787C48472F228D950027A012 /* JSONRPCMessageHandler.swift */,
 				787C48452F228D8C0027A012 /* JSONRPCHTTPHandler.swift */,
 				787C47942F227F6B0027A012 /* RPCMethodHandler.swift */,
-				787C47952F227F6B0027A012 /* XCTestWebSocketServer.swift */,
 			);
 			path = JSONRPC;
 			sourceTree = "<group>";
@@ -591,6 +612,7 @@
 			files = (
 				52D8FAA72D6DD1950015FAB3 /* XCUICoordinate.h in Headers */,
 				52D8FAA52D6DD1950015FAB3 /* XCUIApplicationImpl.h in Headers */,
+				785281492F2BEC40002A7531 /* FBScreenshot.h in Headers */,
 				52D8FAB52D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.h in Headers */,
 				52D8FAA62D6DD1950015FAB3 /* XCUIApplicationProcess.h in Headers */,
 				52D8FAA82D6DD1950015FAB3 /* XCUIDevice.h in Headers */,
@@ -653,9 +675,14 @@
 			dependencies = (
 				52049BF5293503A200807AA3 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				78C54BD12F2D67E300A9369C /* Streamer */,
+			);
 			name = "devicekit-iosUITests";
 			packageProductDependencies = (
 				5279BFD52935ECE20056C609 /* FlyingFox */,
+				78C54B322F2CF23500A9369C /* TCP */,
+				78C54B342F2CF23800A9369C /* H264Codec */,
 			);
 			productName = "maestro-driver-iosUITests";
 			productReference = 52049BF3293503A200807AA3 /* devicekit-iosUITests.xctest */;
@@ -811,15 +838,18 @@
 				612DE4122984114B003C2BE0 /* RunnerDaemonProxy.swift in Sources */,
 				94826F4429DB082100795E9B /* SystemPermissionManager.swift in Sources */,
 				52D8FAAC2D6DD3A20015FAB3 /* FBLogger.m in Sources */,
+				7852814A2F2BEC40002A7531 /* FBScreenshot.m in Sources */,
 				521C1F072D8017480024EE42 /* AXClientProxy.m in Sources */,
 				5261117A2DE5E8E7007C356B /* XCAXClient_iOS+FBSnapshotReqParams.m in Sources */,
 				78147F3D2F27BDBC00E61E3B /* AppsLaunch.swift in Sources */,
 				610D58FB2A49E3CA00B4BBEB /* AXClientSwizzler.swift in Sources */,
 				787C47DF2F228B770027A012 /* IOTap.swift in Sources */,
 				787C47E02F228B770027A012 /* DumpUI.swift in Sources */,
+				78C54BB32F2D4F3400A9369C /* CPUUsageMonitor.swift in Sources */,
 				521C1F102D8051FC0024EE42 /* XCTestDaemonsProxy.m in Sources */,
 				613E87D7299A64BD00FF8551 /* PointerEventPath.swift in Sources */,
 				78147FCB2F27C04400E61E3B /* IOSwipe.swift in Sources */,
+				78C54BCF2F2D5CAD00A9369C /* MetricsReportGenerator.swift in Sources */,
 				787C48482F228D960027A012 /* JSONRPCMessageHandler.swift in Sources */,
 				9811C9092C49751D00DDACA0 /* OrientationGeometry.swift in Sources */,
 				612DE414298426EF003C2BE0 /* EventRecord.swift in Sources */,
@@ -827,12 +857,13 @@
 				787C47982F227F6B0027A012 /* RPCMethodHandler.swift in Sources */,
 				7814800B2F27C56100E61E3B /* IOLongpress.swift in Sources */,
 				781480372F27CEF000E61E3B /* Screenshot.swift in Sources */,
-				787C47992F227F6B0027A012 /* XCTestWebSocketServer.swift in Sources */,
+				787C47992F227F6B0027A012 /* XCTestServer.swift in Sources */,
 				781480752F27D2BB00E61E3B /* URL.swift in Sources */,
 				787C479A2F227F6B0027A012 /* JSONRPCDispatcher.swift in Sources */,
 				521C1F0B2D801A360024EE42 /* XCUIApplication+Helper.m in Sources */,
 				52D8FA9D2D6DCFAF0015FAB3 /* XCUIApplicationProcess+FBQuiescence.m in Sources */,
 				52049BF8293503A200807AA3 /* devicekit_iosUITests.swift in Sources */,
+				78C54BCB2F2D5C4600A9369C /* MemoryUsageMonitor.swift in Sources */,
 				52D8FAB02D6DD4100015FAB3 /* FBConfiguration.m in Sources */,
 				78147F0F2F27AA6B00E61E3B /* IOText.swift in Sources */,
 				6124329E2A4DA5BB00F5F619 /* AXElement.swift in Sources */,
@@ -1001,9 +1032,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1017,7 +1048,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1032,9 +1063,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1048,7 +1079,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1062,9 +1093,9 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1072,7 +1103,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-iosUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-iosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1092,9 +1123,9 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1102,7 +1133,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-iosUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-iosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1122,9 +1153,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1152,7 +1183,7 @@
 					"-DOPUS_BUILD",
 					"-DVAR_ARRAYS",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1173,9 +1204,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1203,7 +1234,7 @@
 					"-DOPUS_BUILD",
 					"-DVAR_ARRAYS",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtension";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1223,9 +1254,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1240,7 +1271,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1260,9 +1291,9 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = MAVP5V2N7V;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1277,7 +1308,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.kvs.mobilenext.devicekit-ios.BroadcastUploadExtensionSetupUI";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1375,6 +1406,16 @@
 		7844BCC02F28128A00F7E003 /* OpusCodec */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = OpusCodec;
+		};
+		78C54B322F2CF23500A9369C /* TCP */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 78F689012F17EDFA0025C8AC /* XCLocalSwiftPackageReference "tcp" */;
+			productName = TCP;
+		};
+		78C54B342F2CF23800A9369C /* H264Codec */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 78F689002F17EDEB0025C8AC /* XCLocalSwiftPackageReference "h264-codec" */;
+			productName = H264Codec;
 		};
 		78F689302F17EE5C0025C8AC /* H264Codec */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/devicekit-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/devicekit-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fcc5a9e047bc89c422e9ca5571e5b664446abc3c4c0b838c23d066c241e1a3f6",
+  "originHash" : "5d27176e6297d604a1a3d3ef5e39315e561ac5c576e5f2c81a9f974b36de9658",
   "pins" : [
     {
       "identity" : "flyingfox",

--- a/devicekit-iosUITests/CPUUsageMonitor.swift
+++ b/devicekit-iosUITests/CPUUsageMonitor.swift
@@ -1,0 +1,45 @@
+final class CPUUsageMonitor {
+    private var lastUserTime: TimeInterval = 0
+    private var lastSystemTime: TimeInterval = 0
+    private var lastTimestamp: TimeInterval = 0
+
+    func cpuUsage() -> Double {
+        var info = task_thread_times_info()
+        var count = mach_msg_type_number_t(MemoryLayout<task_thread_times_info>.size) / 4
+
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_,
+                          task_flavor_t(TASK_THREAD_TIMES_INFO),
+                          $0,
+                          &count)
+            }
+        }
+
+        guard result == KERN_SUCCESS else { return 0 }
+
+        let user = TimeInterval(info.user_time.seconds) +
+                   TimeInterval(info.user_time.microseconds) / 1_000_000
+
+        let system = TimeInterval(info.system_time.seconds) +
+                     TimeInterval(info.system_time.microseconds) / 1_000_000
+
+        let now = CFAbsoluteTimeGetCurrent()
+
+        if lastTimestamp == 0 {
+            lastTimestamp = now
+            lastUserTime = user
+            lastSystemTime = system
+            return 0
+        }
+
+        let deltaTime = now - lastTimestamp
+        let deltaCPU = (user - lastUserTime) + (system - lastSystemTime)
+
+        lastTimestamp = now
+        lastUserTime = user
+        lastSystemTime = system
+
+        return (deltaCPU / deltaTime) * 100
+    }
+}

--- a/devicekit-iosUITests/Categories/devicekit-iosUITests-Bridging-Header.h
+++ b/devicekit-iosUITests/Categories/devicekit-iosUITests-Bridging-Header.h
@@ -30,3 +30,8 @@
 
 /** Custom snapshot parameters (maxDepth, snapshotKeyHonorModalViews). */
 #import "XCAXClient_iOS+FBSnapshotReqParams.h"
+
+// MARK: - Fast Screenshot
+
+/** Fast screenshot capture using XCTest daemon proxy. */
+#import "FBScreenshot.h"

--- a/devicekit-iosUITests/H264Stream/ScreenshotH264Stream.swift
+++ b/devicekit-iosUITests/H264Stream/ScreenshotH264Stream.swift
@@ -1,0 +1,418 @@
+import Foundation
+import CoreImage
+import CoreMedia
+import CoreVideo
+import H264Codec
+import TCP
+import os
+import ImageIO
+import Accelerate
+
+/// Configuration for the H.264 screenshot stream.
+struct H264StreamConfig {
+    /// Target frames per second.
+    var fps: Int = 15
+
+    /// Target bitrate in bits per second.
+    var bitrate: Int = 2_000_000
+
+    /// JPEG quality for screenshot capture (0.0-1.0).
+    var screenshotQuality: Double = 0.5
+
+    /// H.264 encoder quality hint (0.0-1.0).
+    var encoderQuality: Float = 0.5
+
+    /// Scale factor (0.1-1.0). 1.0 = full resolution.
+    var scale: CGFloat = 1.0
+
+    /// TCP port for streaming.
+    var port: UInt16 = 12007
+}
+
+/// Streams H.264 encoded video from screenshots over TCP.
+///
+/// Similar to ScreenStreamer but captures screenshots instead of ReplayKit frames.
+/// Simply forwards NAL units to TCP - no caching or duplicate detection.
+@MainActor
+final class ScreenshotH264Stream {
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: "H264Stream"
+    )
+
+    private var config = H264StreamConfig()
+    private var encoder: H264Encoder?
+    private var tcpServer: TCPServer?
+    private var ciContext: CIContext?
+    private var streamTask: Task<Void, Never>?
+    private var frameNumber: Int64 = 0
+    private var isRunning = false
+    private var pixelBufferPool: CVPixelBufferPool?
+
+    // Cache SPS/PPS/IDR for late-connecting clients
+    private var cachedSPS: Data?
+    private var cachedPPS: Data?
+    private var cachedIDR: Data?
+
+    private let processingQueue = DispatchQueue(
+        label: "h264.screenshot.processing",
+        qos: .userInitiated
+    )
+
+    // Latency tracking
+    private var frameStartTime: UInt64 = 0
+
+    /// Starts the H.264 stream.
+    func start(config: H264StreamConfig = H264StreamConfig()) throws {
+        guard !isRunning else {
+            logger.warning("Stream already running")
+            return
+        }
+
+        self.config = config
+        logger.info("Starting H264 stream: \(config.fps)fps, \(config.bitrate)bps, port=\(config.port)")
+
+        // Initialize Core Image context (GPU-backed)
+        ciContext = CIContext(options: [.useSoftwareRenderer: false])
+
+        // Initialize encoder
+        encoder = H264Encoder()
+
+        let screenSize = getScreenSize()
+        let width = Int32(screenSize.width * config.scale)
+        let height = Int32(screenSize.height * config.scale)
+
+        logger.info("Encoder dimensions: \(width)x\(height)")
+
+        // Create pixel buffer pool for reuse (avoids allocation per frame)
+        let poolAttrs: [CFString: Any] = [
+            kCVPixelBufferPoolMinimumBufferCountKey: 3
+        ]
+        let pixelBufferAttrs: [CFString: Any] = [
+            kCVPixelBufferWidthKey: width,
+            kCVPixelBufferHeightKey: height,
+            kCVPixelBufferPixelFormatTypeKey: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferIOSurfacePropertiesKey: [:],  // IOSurface-backed for GPU
+            kCVPixelBufferMetalCompatibilityKey: true
+        ]
+        CVPixelBufferPoolCreate(
+            kCFAllocatorDefault,
+            poolAttrs as CFDictionary,
+            pixelBufferAttrs as CFDictionary,
+            &pixelBufferPool
+        )
+
+        try encoder?.configureCompressSession(
+            width: width,
+            height: height,
+            isRealTime: true,
+            expectedFrameRate: config.fps,
+            averageBitRate: config.bitrate,
+            quality: config.encoderQuality
+        )
+
+        encoder?.naluHandling = { [weak self] data in
+            guard let self else { return }
+            tcpServer?.dataHandler?(data)
+        }
+
+        // Initialize TCP server
+        tcpServer = TCPServer()
+        tcpServer?.onClientConnected = { [weak self] in
+            guard let self = self else {
+                print("[H264Stream] onClientConnected: self is nil")
+                return
+            }
+
+            print("[H264Stream] Client connected! Sending cached data...")
+
+            guard let handler = self.tcpServer?.dataHandler else {
+                print("[H264Stream] ERROR: dataHandler is nil!")
+                return
+            }
+
+            // Send cached data immediately when client connects
+            let sps = self.cachedSPS
+            let pps = self.cachedPPS
+            let idr = self.cachedIDR
+
+            if let sps = sps {
+                print("[H264Stream] Sending cached SPS (\(sps.count) bytes)")
+                handler(sps)
+            } else {
+                print("[H264Stream] WARNING: No cached SPS!")
+            }
+
+            if let pps = pps {
+                print("[H264Stream] Sending cached PPS (\(pps.count) bytes)")
+                handler(pps)
+            } else {
+                print("[H264Stream] WARNING: No cached PPS!")
+            }
+
+            if let idr = idr {
+                print("[H264Stream] Sending cached IDR (\(idr.count) bytes)")
+                handler(idr)
+            } else {
+                print("[H264Stream] WARNING: No cached IDR!")
+            }
+        }
+        try tcpServer?.start(port: config.port)
+
+        // Start capture loop
+        isRunning = true
+        frameNumber = 0
+        streamTask = Task { [weak self] in
+            await self?.captureLoop()
+        }
+
+        logger.info("H264 stream started on port \(config.port)")
+    }
+
+    /// Stops the stream.
+    func stop() {
+        guard isRunning else { return }
+
+        logger.info("Stopping H264 stream")
+
+        isRunning = false
+        streamTask?.cancel()
+        streamTask = nil
+
+        encoder?.invalidateCompressionSession()
+        encoder = nil
+
+        tcpServer?.stop()
+        tcpServer = nil
+
+        ciContext = nil
+        pixelBufferPool = nil
+        cachedSPS = nil
+        cachedPPS = nil
+        cachedIDR = nil
+    }
+
+    /// Updates encoder settings dynamically.
+    func updateConfig(bitrate: Int? = nil, fps: Int? = nil) {
+        if let bitrate = bitrate {
+            config.bitrate = bitrate
+        }
+        if let fps = fps {
+            config.fps = fps
+        }
+
+        try? encoder?.updateEncoderSettings(
+            newBitrate: config.bitrate,
+            newFrameRate: fps
+        )
+    }
+
+    // MARK: - Private
+
+    private func captureLoop() async {
+        let frameInterval = UInt64(1_000_000_000 / max(1, config.fps))
+
+        while !Task.isCancelled && isRunning {
+            let startTime = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+
+            await captureAndEncodeFrame()
+
+            // Maintain frame rate
+            let elapsed = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - startTime
+            if elapsed < frameInterval {
+                try? await Task.sleep(nanoseconds: frameInterval - elapsed)
+            }
+        }
+    }
+
+    private func captureAndEncodeFrame() async {
+        let t0 = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+
+        // 1. Capture stays on MainActor
+        guard let uiImage = try? FBScreenshot.captureUIImage(
+            withQuality: config.screenshotQuality,
+            timeout: 0.5
+        ) else {
+            logger.error("UIImage capture failed")
+            return
+        }
+
+        let t1 = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        let captureMs = Double(t1 - t0) / 1_000_000
+
+        // 2. Heavy work off-main
+        let config = self.config
+        let ciContext = self.ciContext
+        let encoder = self.encoder
+        let pixelBufferPool = self.pixelBufferPool
+        let frameNumber = self.frameNumber
+
+        Task.detached { [logger] in
+            let t2 = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+
+            guard let scaledImage = UIImageScaler.scaleImage(uiImage, scaleFactor: config.scale),
+                  let pixelBuffer = await self.uiImageToPixelBuffer(
+                      from: scaledImage,
+                      size: scaledImage.size,
+                  ) else {
+                logger.warning("UIImage to pixel buffer conversion failed")
+                return
+            }
+
+            let t3 = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+            let convertMs = Double(t3 - t2) / 1_000_000
+
+            guard let ciContext, let encoder else { return }
+
+            let timestamp = CMTime(value: frameNumber, timescale: Int32(config.fps))
+
+            encoder.encode(
+                imageBuffer: pixelBuffer,
+                timestamp: timestamp,
+                context: ciContext,
+                orientation: .up
+            )
+
+            let t4 = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+            let encodeSubmitMs = Double(t4 - t3) / 1_000_000
+
+            if frameNumber % 30 == 0 {
+                logger.info(
+                    "Frame \(frameNumber): capture=\(captureMs)ms, convert=\(convertMs)ms, submit=\(encodeSubmitMs)ms"
+                )
+            }
+        }
+
+        // 3. Only frameNumber mutation stays on MainActor
+        self.frameNumber += 1
+    }
+
+
+    func uiImageToPixelBuffer(
+        from image: UIImage,
+        size: CGSize,
+    ) -> CVPixelBuffer? {
+
+        guard let cgImage = image.cgImage else { return nil }
+
+        var pixelBuffer: CVPixelBuffer?
+
+        // Reuse from pool if available (much faster!)
+        if let pool = pixelBufferPool {
+            CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
+        } else {
+            let attrs: CFDictionary = [
+                kCVPixelBufferCGImageCompatibilityKey: kCFBooleanTrue!,
+                kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue!,
+                kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary
+            ] as CFDictionary
+
+            CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                Int(size.width),
+                Int(size.height),
+                kCVPixelFormatType_32BGRA, // Native iOS format
+                attrs,
+                &pixelBuffer
+            )
+        }
+
+        guard let buffer = pixelBuffer else { return nil }
+
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+        guard let data = CVPixelBufferGetBaseAddress(buffer) else { return nil }
+
+        let rgbColorSpace = CGColorSpaceCreateDeviceRGB()
+
+        let context = CGContext(
+            data: data,
+            width: Int(size.width),
+            height: Int(size.height),
+            bitsPerComponent: 8,
+            bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+            space: rgbColorSpace,
+            bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue |
+                        CGBitmapInfo.byteOrder32Little.rawValue
+        )
+
+        context?.draw(cgImage, in: CGRect(origin: .zero, size: size))
+
+        return buffer
+    }
+
+
+    private func getScreenSize() -> CGSize {
+        let screen = UIScreen.main
+        return CGSize(
+            width: screen.bounds.width * screen.scale,
+            height: screen.bounds.height * screen.scale
+        )
+    }
+}
+
+/// Utility for scaling UIImages using Core Graphics.
+private enum UIImageScaler {
+
+    /// Scales a UIImage by a given factor.
+    ///
+    /// - Parameters:
+    ///   - image: Original UIImage.
+    ///   - scaleFactor: Scale factor (0.0–1.0). 0.5 = 50% of original size.
+    ///   - interpolation: Quality used when scaling (default: .medium).
+    /// - Returns: A new scaled UIImage, or nil if scaling failed.
+    static func scaleImage(
+        _ image: UIImage,
+        scaleFactor: CGFloat,
+        interpolation: CGInterpolationQuality = .medium
+    ) -> UIImage? {
+
+        guard scaleFactor > 0 && scaleFactor < 1 else {
+            return image // No scaling needed
+        }
+
+        guard let cgImage = image.cgImage else {
+            return nil
+        }
+
+        // Original dimensions
+        let originalWidth = CGFloat(cgImage.width)
+        let originalHeight = CGFloat(cgImage.height)
+
+        // New dimensions
+        let newWidth = Int(originalWidth * scaleFactor)
+        let newHeight = Int(originalHeight * scaleFactor)
+
+        guard newWidth > 0 && newHeight > 0 else {
+            return nil
+        }
+
+        // Create bitmap context
+        guard let context = CGContext(
+            data: nil,
+            width: newWidth,
+            height: newHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        context.interpolationQuality = interpolation
+
+        // Draw scaled image
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+
+        // Extract scaled CGImage
+        guard let scaledCGImage = context.makeImage() else {
+            return nil
+        }
+
+        // Preserve original scale + orientation
+        return UIImage(cgImage: scaledCGImage, scale: image.scale, orientation: image.imageOrientation)
+    }
+}

--- a/devicekit-iosUITests/MemoryUsageMonitor.swift
+++ b/devicekit-iosUITests/MemoryUsageMonitor.swift
@@ -1,0 +1,13 @@
+final class MemoryUsageMonitor {
+    /// Get current memory footprint in bytes
+    func getMemoryFootprint() -> UInt64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        return result == KERN_SUCCESS ? UInt64(info.phys_footprint) : 0
+    }
+}

--- a/devicekit-iosUITests/MetricsReportGenerator.swift
+++ b/devicekit-iosUITests/MetricsReportGenerator.swift
@@ -1,0 +1,82 @@
+enum MetricValue {
+    case int(Int)
+    case uint(UInt64)
+    case double(Double)
+    case string(String)
+}
+
+struct Metric {
+    let name: String
+    let value: MetricValue
+    let unit: String?
+}
+
+struct DistributionMetric {
+    let name: String
+    let values: [UInt64]  // nanoseconds or bytes or whatever
+    let unit: String?
+}
+
+protocol MetricComputer {
+    func average(_ values: [UInt64]) -> Double
+    func percentile(_ values: [UInt64], _ p: Double) -> Double
+}
+
+final class DefaultMetricComputer: MetricComputer {
+    func average(_ values: [UInt64]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        return Double(values.reduce(0, +)) / Double(values.count)
+    }
+
+    func percentile(_ values: [UInt64], _ p: Double) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let idx = Int(Double(sorted.count - 1) * p)
+        return Double(sorted[idx])
+    }
+}
+
+struct ReportSection {
+    let title: String
+    let metrics: [Metric]
+}
+
+final class AsciiReportRenderer {
+    func render(sections: [ReportSection], title: String) -> String {
+        var out = ""
+        out += "╔" + String(repeating: "═", count: 70) + "╗\n"
+        out += "║" + title.centered(width: 70) + "║\n"
+        out += "╠" + String(repeating: "═", count: 70) + "╣\n"
+
+        for (i, section) in sections.enumerated() {
+            out += "║ \(section.title.uppercased())\n"
+            for metric in section.metrics {
+                out += "║   \(metric.name): \(format(metric))\n"
+            }
+            if i < sections.count - 1 {
+                out += "╠" + String(repeating: "═", count: 70) + "╣\n"
+            }
+        }
+
+        out += "╚" + String(repeating: "═", count: 70) + "╝"
+        return out
+    }
+
+    private func format(_ metric: Metric) -> String {
+        switch metric.value {
+        case .int(let v): return "\(v)\(metric.unit ?? "")"
+        case .uint(let v): return "\(v)\(metric.unit ?? "")"
+        case .double(let v): return String(format: "%.2f%@", v, metric.unit ?? "")
+        case .string(let s): return s
+        }
+    }
+}
+
+private extension String {
+    func centered(width: Int) -> String {
+        let padding = max(0, width - count)
+        let left = padding / 2
+        let right = padding - left
+        return String(repeating: " ", count: left) + self + String(repeating: " ", count: right)
+    }
+}

--- a/devicekit-iosUITests/Streamer/H264/H264.swift
+++ b/devicekit-iosUITests/Streamer/H264/H264.swift
@@ -1,0 +1,186 @@
+import FlyingFox
+import FlyingSocks
+import Foundation
+import os
+import CoreImage
+import CoreMedia
+import H264Codec
+
+// MARK: - Constants
+
+private enum H264Constants {
+    static let defaultFPS: Int = 30
+    static let maxFPS: Int = 60
+    static let defaultBitrate: Int = 4_000_000
+    static let minBitrate: Int = 100_000
+    static let maxBitrate: Int = 10_000_000
+    static let defaultQuality: Int = 60
+    static let defaultScale: Int = 50
+    static let minScale: Int = 10
+    static let maxScale: Int = 100
+}
+
+// MARK: - Stream Configuration
+
+struct H264StreamConfig: Sendable {
+    let fps: Int
+    let bitrate: Int
+    let quality: Float
+    let scale: Float
+    let frameInterval: UInt64
+
+    init(fps: Int, bitrate: Int, quality: Float, scale: Float) {
+        self.fps = fps
+        self.bitrate = bitrate
+        self.quality = quality
+        self.scale = scale
+        self.frameInterval = UInt64(1_000_000_000 / max(1, fps))
+    }
+}
+
+// MARK: - HTTP Handler
+
+/// HTTP handler for H.264 video streaming endpoint.
+///
+/// Streams H.264 encoded video over HTTP. Connect with:
+/// ```bash
+/// curl http://127.0.0.1:12004/h264 | ffplay -fflags nobuffer -flags low_delay -f h264 -
+/// ```
+@MainActor
+struct H264HTTPHandler: HTTPHandler {
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: "H264Stream"
+    )
+
+    func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let fps = parseQueryInt(from: request, name: "fps", default: H264Constants.defaultFPS, min: 1, max: H264Constants.maxFPS)
+        let bitrate = parseQueryInt(from: request, name: "bitrate", default: H264Constants.defaultBitrate, min: H264Constants.minBitrate, max: H264Constants.maxBitrate)
+        let quality = Float(parseQueryInt(from: request, name: "quality", default: H264Constants.defaultQuality, min: 1, max: 100)) / 100.0
+        let scalePercent = parseQueryInt(from: request, name: "scale", default: H264Constants.defaultScale, min: H264Constants.minScale, max: H264Constants.maxScale)
+        let scale = Float(scalePercent) / 100.0
+
+        logger.info("Starting H264 stream: scale=\(scalePercent)% @ \(fps)fps, \(bitrate/1_000_000)Mbps")
+
+        let config = H264StreamConfig(fps: fps, bitrate: bitrate, quality: quality, scale: scale)
+        let stream = H264ByteStream(config: config)
+        let bodySequence = HTTPBodySequence(from: stream)
+
+        var headers: [HTTPHeader: String] = [:]
+        headers[.contentType] = "video/h264"
+        headers[HTTPHeader("Server")] = "DeviceKit-iOS"
+        headers[HTTPHeader("Connection")] = "close"
+        headers[HTTPHeader("Cache-Control")] = "no-cache, no-store, must-revalidate"
+
+        return HTTPResponse(statusCode: .ok, headers: headers, body: bodySequence)
+    }
+
+    private func parseQueryInt(from request: HTTPRequest, name: String, default defaultValue: Int, min minValue: Int, max maxValue: Int) -> Int {
+        guard let param = request.query.first(where: { $0.name == name }),
+              let intValue = Int(param.value) else {
+            return defaultValue
+        }
+        return Swift.max(minValue, Swift.min(maxValue, intValue))
+    }
+}
+
+// MARK: - Byte Stream
+
+struct H264ByteStream: AsyncBufferedSequence, Sendable {
+    typealias Element = UInt8
+
+    let config: H264StreamConfig
+
+    func makeAsyncIterator() -> H264ByteIterator {
+        H264ByteIterator(config: config)
+    }
+}
+
+// MARK: - Iterator
+
+final class H264ByteIterator: AsyncBufferedIteratorProtocol, @unchecked Sendable {
+    typealias Element = UInt8
+    typealias Buffer = [UInt8]
+
+    private let config: H264StreamConfig
+    private let frameProducer: H264FrameProducer
+    private let metrics: H264Metrics
+    private var naluStream: AsyncStream<Data>?
+    private var naluIterator: AsyncStream<Data>.Iterator?
+    private var captureTask: Task<Void, Never>?
+    private var isCancelled = false
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: "H264Iterator"
+    )
+
+    init(config: H264StreamConfig) {
+        self.config = config
+        self.metrics = H264Metrics(targetFPS: config.fps, targetBitrate: config.bitrate)
+        self.frameProducer = H264FrameProducer(metrics: metrics)
+
+        // Create NAL unit stream and start capture loop
+        let stream = frameProducer.makeNALUnitStream()
+        self.naluStream = stream
+        self.naluIterator = stream.makeAsyncIterator()
+
+        // Start background capture loop
+        startCaptureLoop()
+    }
+
+    deinit {
+        captureTask?.cancel()
+        frameProducer.invalidateEncoder()
+        metrics.logSummary()
+    }
+
+    private func startCaptureLoop() {
+        captureTask = Task { [weak self] in
+            guard let self = self else { return }
+
+            while !Task.isCancelled {
+                do {
+                    try await self.captureFrame()
+                } catch {
+                    self.logger.error("Capture error: \(error.localizedDescription)")
+                    break
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func captureFrame() async throws {
+        try await frameProducer.captureAndEncodeFrame(
+            fps: config.fps,
+            bitrate: config.bitrate,
+            quality: config.quality,
+            scale: config.scale,
+            frameInterval: config.frameInterval
+        )
+    }
+
+    func next() async throws -> UInt8? {
+        guard !isCancelled, !Task.isCancelled else { return nil }
+        let buffer = try await nextBuffer(suggested: 1)
+        return buffer?.first
+    }
+
+    func nextBuffer(suggested count: Int) async throws -> [UInt8]? {
+        guard !isCancelled, !Task.isCancelled else {
+            metrics.logSummary()
+            return nil
+        }
+
+        // Get next NAL unit from the stream
+        guard let data = await naluIterator?.next() else {
+            isCancelled = true
+            metrics.logSummary()
+            return nil
+        }
+
+        return Array(data)
+    }
+}

--- a/devicekit-iosUITests/Streamer/H264/H264FrameProducer.swift
+++ b/devicekit-iosUITests/Streamer/H264/H264FrameProducer.swift
@@ -1,0 +1,202 @@
+import CoreImage
+import CoreMedia
+import H264Codec
+import os
+
+enum H264Error: Error, LocalizedError {
+    case captureFailed
+    case conversionFailed
+    case encoderNotConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .captureFailed: return "Screenshot capture failed"
+        case .conversionFailed: return "Pixel buffer conversion failed"
+        case .encoderNotConfigured: return "Encoder not configured"
+        }
+    }
+}
+
+/// Produces H264 encoded frames from screen captures.
+/// Uses AsyncStream for thread-safe NAL unit delivery.
+final class H264FrameProducer: @unchecked Sendable {
+
+    private let captureTimeout: TimeInterval = 0.5
+    private let metricsReportInterval: UInt64 = 30
+
+    private var encoder: H264Encoder?
+    private var ciContext: CIContext?
+    private var pixelBufferPool: CVPixelBufferPool?
+    private var targetSize: CGSize?
+    private var isConfigured = false
+    private var frameCount: UInt64 = 0
+
+    // AsyncStream for thread-safe NAL unit delivery
+    private var continuation: AsyncStream<Data>.Continuation?
+
+    // Metrics
+    private let metrics: H264Metrics
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: "H264FrameProducer"
+    )
+
+    init(metrics: H264Metrics) {
+        self.metrics = metrics
+    }
+
+    /// Creates an AsyncStream that yields NAL units as they're encoded.
+    func makeNALUnitStream() -> AsyncStream<Data> {
+        AsyncStream { continuation in
+            self.continuation = continuation
+
+            continuation.onTermination = { [weak self] _ in
+                self?.invalidateEncoder()
+            }
+        }
+    }
+
+    /// Invalidates the encoder session.
+    func invalidateEncoder() {
+        encoder?.invalidateCompressionSession()
+        continuation?.finish()
+        continuation = nil
+    }
+
+    /// Captures a screenshot and encodes it to H264.
+    /// NAL units are delivered via the AsyncStream.
+    @MainActor
+    func captureAndEncodeFrame(
+        fps: Int,
+        bitrate: Int,
+        quality: Float,
+        scale: Float,
+        frameInterval: UInt64
+    ) async throws {
+        let frameStart = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+
+        // Capture screenshot
+        let captureStart = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        guard let uiImage = try? FBScreenshot.captureUIImage(
+            withQuality: 0.9,
+            timeout: captureTimeout
+        ), let cgImage = uiImage.cgImage else {
+            metrics.recordCapture(durationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - captureStart, success: false)
+            throw H264Error.captureFailed
+        }
+        metrics.recordCapture(durationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - captureStart, success: true)
+
+        // Configure encoder on first frame
+        if !isConfigured {
+            try configureEncoder(
+                for: cgImage,
+                fps: fps,
+                bitrate: bitrate,
+                quality: quality,
+                scale: scale
+            )
+        }
+
+        guard let ciContext = ciContext,
+              let targetSize = targetSize,
+              let encoder = encoder else {
+            throw H264Error.encoderNotConfigured
+        }
+
+        // Convert to pixel buffer using GPU
+        let convertStart = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        guard let pixelBuffer = cgImage.toPixelBuffer(
+            context: ciContext,
+            targetSize: targetSize,
+            pool: pixelBufferPool
+        ) else {
+            metrics.recordConversion(durationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - convertStart, success: false)
+            throw H264Error.conversionFailed
+        }
+        metrics.recordConversion(durationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - convertStart, success: true)
+
+        // Encode frame - NAL units delivered via continuation
+        let encodeStart = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        let timestamp = CMTime(
+            value: CMTimeValue(frameCount),
+            timescale: CMTimeScale(fps)
+        )
+        encoder.encode(pixelBuffer: pixelBuffer, timestamp: timestamp)
+        metrics.recordEncode(durationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - encodeStart, success: true)
+        frameCount += 1
+
+        // Record frame completion
+        metrics.recordFrameComplete(totalDurationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - frameStart)
+
+        // Log metrics periodically
+        if frameCount % metricsReportInterval == 0 {
+            metrics.logSummary()
+        }
+
+        // Maintain frame rate
+        let elapsed = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - frameStart
+        if elapsed < frameInterval {
+            try await Task.sleep(nanoseconds: frameInterval - elapsed)
+        } else {
+            metrics.recordFrameSkipped()
+        }
+    }
+
+    private func configureEncoder(
+        for cgImage: CGImage,
+        fps: Int,
+        bitrate: Int,
+        quality: Float,
+        scale: Float
+    ) throws {
+        let originalWidth = CGFloat(cgImage.width)
+        let originalHeight = CGFloat(cgImage.height)
+
+        // Ensure even dimensions (H264 requirement)
+        var scaledWidth = Int(originalWidth * CGFloat(scale))
+        var scaledHeight = Int(originalHeight * CGFloat(scale))
+        scaledWidth = scaledWidth - (scaledWidth % 2)
+        scaledHeight = scaledHeight - (scaledHeight % 2)
+        scaledWidth = max(64, scaledWidth)
+        scaledHeight = max(64, scaledHeight)
+
+        targetSize = CGSize(width: scaledWidth, height: scaledHeight)
+
+        logger.info("Encoder: \(scaledWidth)x\(scaledHeight) @ \(fps)fps, \(bitrate/1_000_000)Mbps")
+
+        // GPU-accelerated context
+        ciContext = CIContext(options: [
+            .useSoftwareRenderer: false,
+            .highQualityDownsample: false
+        ])
+
+        // Pixel buffer pool for reuse
+        pixelBufferPool = CGImage.createPixelBufferPool(
+            size: targetSize!,
+            minimumBufferCount: 3
+        )
+
+        // Configure encoder
+        let enc = H264Encoder()
+        try enc.configureCompressSession(
+            width: Int32(scaledWidth),
+            height: Int32(scaledHeight),
+            isRealTime: true,
+            expectedFrameRate: fps,
+            averageBitRate: bitrate,
+            quality: quality
+        )
+
+        // Deliver NAL units via AsyncStream continuation (thread-safe)
+        enc.naluHandling = { [weak self] data in
+            guard let self = self else { return }
+            let isIDR = data.count > 4 && (data[4] & 0x1F) == 5
+            self.metrics.recordNALU(size: data.count, isIDR: isIDR)
+            self.continuation?.yield(data)
+        }
+
+        encoder = enc
+        isConfigured = true
+    }
+}

--- a/devicekit-iosUITests/Streamer/H264/H264Metrics.swift
+++ b/devicekit-iosUITests/Streamer/H264/H264Metrics.swift
@@ -1,0 +1,286 @@
+import os
+
+/// Comprehensive metrics collector for H264 streaming performance analysis.
+final class H264Metrics: @unchecked Sendable {
+
+    // MARK: - Timing Metrics (all in nanoseconds)
+
+    private var captureTimes: [UInt64] = []
+    private var convertTimes: [UInt64] = []
+    private var encodeTimes: [UInt64] = []
+    private var frameTimes: [UInt64] = []
+    private var frameIntervals: [UInt64] = []
+
+    // MARK: - Frame Counters
+
+    private(set) var framesCapured: UInt64 = 0
+    private(set) var framesEncoded: UInt64 = 0
+    private(set) var framesDroppedCapture: UInt64 = 0
+    private(set) var framesDroppedConversion: UInt64 = 0
+    private(set) var framesDroppedEncoding: UInt64 = 0
+    private(set) var framesSkipped: UInt64 = 0
+
+    // MARK: - Data Metrics
+
+    private(set) var totalBytesOutput: UInt64 = 0
+    private(set) var naluCount: UInt64 = 0
+    private(set) var idrFrameCount: UInt64 = 0
+    private var naluSizes: [Int] = []
+
+    // MARK: - System Metrics
+
+    private let sessionStartTime: UInt64
+    private var lastFrameTime: UInt64 = 0
+    private let targetFPS: Int
+    private let targetBitrate: Int
+
+    private let lock = NSLock()
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: "H264Metrics"
+    )
+
+    init(targetFPS: Int, targetBitrate: Int) {
+        self.targetFPS = targetFPS
+        self.targetBitrate = targetBitrate
+        self.sessionStartTime = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+    }
+
+    // MARK: - Recording Methods
+
+    func recordCapture(durationNs: UInt64, success: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if success {
+            captureTimes.append(durationNs)
+            framesCapured += 1
+        } else {
+            framesDroppedCapture += 1
+        }
+    }
+
+    func recordConversion(durationNs: UInt64, success: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if success {
+            convertTimes.append(durationNs)
+        } else {
+            framesDroppedConversion += 1
+        }
+    }
+
+    func recordEncode(durationNs: UInt64, success: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if success {
+            encodeTimes.append(durationNs)
+            framesEncoded += 1
+        } else {
+            framesDroppedEncoding += 1
+        }
+    }
+
+    func recordFrameComplete(totalDurationNs: UInt64) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        frameTimes.append(totalDurationNs)
+
+        let now = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        if lastFrameTime > 0 {
+            frameIntervals.append(now - lastFrameTime)
+        }
+        lastFrameTime = now
+    }
+
+    func recordNALU(size: Int, isIDR: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        totalBytesOutput += UInt64(size)
+        naluCount += 1
+        naluSizes.append(size)
+        if isIDR {
+            idrFrameCount += 1
+        }
+    }
+
+    func recordFrameSkipped() {
+        lock.lock()
+        defer { lock.unlock() }
+        framesSkipped += 1
+    }
+
+    // MARK: - Statistics Calculation
+
+    private func percentile(_ values: [UInt64], _ p: Double) -> UInt64 {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let index = Int(Double(sorted.count - 1) * p)
+        return sorted[index]
+    }
+
+    private func average(_ values: [UInt64]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        return Double(values.reduce(0, +)) / Double(values.count)
+    }
+
+    private func getMemoryFootprint() -> UInt64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        return result == KERN_SUCCESS ? UInt64(info.phys_footprint) : 0
+    }
+
+    private func getCPUUsage() -> Double {
+        CPUUsageMonitor().cpuUsage()
+    }
+
+    // MARK: - Report sections
+
+    private func buildSections() -> [ReportSection] {
+        let now = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        let sessionDurationSec = Double(now - sessionStartTime) / 1_000_000_000
+
+        let avgCaptureMs = average(captureTimes) / 1_000_000
+        let avgConvertMs = average(convertTimes) / 1_000_000
+        let avgEncodeMs = average(encodeTimes) / 1_000_000
+        let avgFrameMs = average(frameTimes) / 1_000_000
+
+        let p50FrameMs = Double(percentile(frameTimes, 0.50)) / 1_000_000
+        let p95FrameMs = Double(percentile(frameTimes, 0.95)) / 1_000_000
+        let p99FrameMs = Double(percentile(frameTimes, 0.99)) / 1_000_000
+
+        let avgIntervalNs = average(frameIntervals)
+        let actualFPS = avgIntervalNs > 0 ? 1_000_000_000 / avgIntervalNs : 0
+
+        let bandwidthBps = sessionDurationSec > 0 ? Double(totalBytesOutput * 8) / sessionDurationSec : 0
+        let bandwidthKbps = bandwidthBps / 1000
+        let bandwidthMbps = bandwidthBps / 1_000_000
+
+        let throughput = sessionDurationSec > 0 ? Double(framesEncoded) / sessionDurationSec : 0
+
+        let avgNaluSize = naluSizes.isEmpty ? 0 : naluSizes.reduce(0, +) / naluSizes.count
+
+        let totalDropped = framesDroppedCapture + framesDroppedConversion + framesDroppedEncoding
+        let totalAttempted = framesCapured + framesDroppedCapture
+        let dropRate = totalAttempted > 0 ? Double(totalDropped) / Double(totalAttempted) * 100 : 0
+
+        let memoryMB = Double(getMemoryFootprint()) / 1_000_000
+        let cpuUsage = getCPUUsage()
+
+        let fpsEfficiency = actualFPS / Double(targetFPS) * 100
+        let bitrateEfficiency = bandwidthBps > 0 ? bandwidthBps / Double(targetBitrate) * 100 : 0
+
+        let session = ReportSection(
+            title: "Session",
+            metrics: [
+                Metric(name: "Duration", value: .double(sessionDurationSec), unit: "s"),
+                Metric(name: "Frames Encoded", value: .uint(framesEncoded), unit: nil),
+                Metric(name: "Frames Captured", value: .uint(framesCapured), unit: nil),
+                Metric(name: "Frames Skipped", value: .uint(framesSkipped), unit: nil)
+            ]
+        )
+
+        let timing = ReportSection(
+            title: "Timing (ms)",
+            metrics: [
+                Metric(name: "Capture avg", value: .double(avgCaptureMs), unit: "ms"),
+                Metric(name: "Convert avg", value: .double(avgConvertMs), unit: "ms"),
+                Metric(name: "Encode avg", value: .double(avgEncodeMs), unit: "ms"),
+                Metric(name: "Frame avg", value: .double(avgFrameMs), unit: "ms"),
+                Metric(name: "Frame p50", value: .double(p50FrameMs), unit: "ms"),
+                Metric(name: "Frame p95", value: .double(p95FrameMs), unit: "ms"),
+                Metric(name: "Frame p99", value: .double(p99FrameMs), unit: "ms")
+            ]
+        )
+
+        let video = ReportSection(
+            title: "Video",
+            metrics: [
+                Metric(name: "Target FPS", value: .int(targetFPS), unit: nil),
+                Metric(name: "Actual FPS", value: .double(actualFPS), unit: nil),
+                Metric(name: "FPS Efficiency", value: .double(fpsEfficiency), unit: "%"),
+                Metric(name: "Throughput", value: .double(throughput), unit: " frames/sec"),
+                Metric(name: "Frame Drops", value: .uint(totalDropped), unit: nil),
+                Metric(name: "Drop Rate", value: .double(dropRate), unit: "%"),
+                Metric(name: "Dropped (capture)", value: .uint(framesDroppedCapture), unit: nil),
+                Metric(name: "Dropped (convert)", value: .uint(framesDroppedConversion), unit: nil),
+                Metric(name: "Dropped (encode)", value: .uint(framesDroppedEncoding), unit: nil)
+            ]
+        )
+
+        let bandwidth = ReportSection(
+            title: "Bandwidth",
+            metrics: [
+                Metric(
+                    name: "Target Bitrate",
+                    value: .double(Double(targetBitrate) / 1_000_000),
+                    unit: " Mbps"
+                ),
+                Metric(
+                    name: "Actual Bitrate",
+                    value: .double(bandwidthMbps),
+                    unit: " Mbps"
+                ),
+                Metric(
+                    name: "Bitrate Efficiency",
+                    value: .double(bitrateEfficiency),
+                    unit: "%"
+                ),
+                Metric(
+                    name: "Rate (kbps)",
+                    value: .double(bandwidthKbps),
+                    unit: " kbps"
+                ),
+                Metric(
+                    name: "Total Data",
+                    value: .double(Double(totalBytesOutput) / 1_000_000),
+                    unit: " MB"
+                )
+            ]
+        )
+
+        let nal = ReportSection(
+            title: "NAL Units",
+            metrics: [
+                Metric(name: "Total NALs", value: .uint(naluCount), unit: nil),
+                Metric(name: "IDR Frames", value: .uint(idrFrameCount), unit: nil),
+                Metric(name: "Avg NAL Size", value: .int(avgNaluSize), unit: " bytes")
+            ]
+        )
+
+        let system = ReportSection(
+            title: "System",
+            metrics: [
+                Metric(name: "Memory", value: .double(memoryMB), unit: " MB"),
+                Metric(name: "CPU", value: .double(cpuUsage), unit: "%")
+            ]
+        )
+
+        return [session, timing, video, bandwidth, nal, system]
+    }
+
+    // MARK: - Report Generation
+
+    func generateReport() -> String {
+        let sections = buildSections()
+
+        return AsciiReportRenderer().render(
+            sections: sections,
+            title: "H264 STREAM METRICS REPORT"
+        )
+    }
+
+    func logSummary() {
+        logger.info("\n\(self.generateReport())")
+    }
+}

--- a/devicekit-iosUITests/Streamer/MJPEG/MJPEG.swift
+++ b/devicekit-iosUITests/Streamer/MJPEG/MJPEG.swift
@@ -1,0 +1,194 @@
+import FlyingFox
+import FlyingSocks
+import Foundation
+import os
+import XCTest
+import CoreGraphics
+import ImageIO
+
+/// Configuration constants for MJPEG streaming.
+private enum MJPEGConstants {
+    /// Default frames per second for the MJPEG stream.
+    static let defaultFPS: Int = 10
+
+    /// Maximum frames per second allowed.
+    static let maxFPS: Int = 60
+
+    /// Default JPEG compression quality (0.0 - 1.0).
+    static let defaultQuality: CGFloat = 0.25
+
+    /// Minimum JPEG quality allowed.
+    static let minQuality: CGFloat = 0.01
+
+    /// Maximum JPEG quality allowed.
+    static let maxQuality: CGFloat = 1.0
+
+    /// Default scaling factor (100 = no scaling).
+    static let defaultScale: Int = 100
+
+    /// Minimum scaling factor (10%).
+    static let minScale: Int = 10
+
+    /// Maximum scaling factor (100%).
+    static let maxScale: Int = 100
+
+    /// Server name for HTTP response header.
+    static let serverName = "DeviceKit-iOS"
+}
+
+/// HTTP handler for MJPEG video streaming endpoint.
+///
+/// This handler captures screenshots at a configurable frame rate and streams
+/// them as MJPEG (Motion JPEG) over HTTP using multipart/x-mixed-replace.
+///
+/// Uses the fast XCTest daemon proxy for screenshot capture with JPEG
+/// compression at the source level for optimal performance.
+///
+/// ## URL Query Parameters
+/// - `fps`: Frame rate (1-60, default: 10)
+/// - `quality`: JPEG quality (1-100, default: 25)
+/// - `scale`: Image scale (10-100, default: 100 = no scaling)
+///
+/// ## Example Usage
+/// ```bash
+/// # Stream with default settings (10 fps, 25% quality, full resolution)
+/// curl http://127.0.0.1:12004/mjpeg --output stream.mjpeg
+///
+/// # Stream with higher FPS and quality
+/// curl "http://127.0.0.1:12004/mjpeg?fps=30&quality=50" --output stream.mjpeg
+///
+/// # Stream with reduced resolution for lower bandwidth
+/// curl "http://127.0.0.1:12004/mjpeg?fps=15&quality=30&scale=50" --output stream.mjpeg
+///
+/// # View in VLC or browser
+/// vlc http://127.0.0.1:12004/mjpeg
+/// # Or open in browser: http://127.0.0.1:12004/mjpeg
+/// ```
+@MainActor
+struct MJPEGHTTPHandler: HTTPHandler {
+    private let boundary = "mjpeg-frame-boundary"
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: "MJPEGStream"
+    )
+
+    func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
+        // Parse query parameters
+        let fps = parseQueryInt(from: request, name: "fps", default: MJPEGConstants.defaultFPS, min: 1, max: MJPEGConstants.maxFPS)
+        let qualityPercent = parseQueryInt(from: request, name: "quality", default: 25, min: 1, max: 100)
+        let scalePercent = parseQueryInt(from: request, name: "scale", default: MJPEGConstants.defaultScale, min: MJPEGConstants.minScale, max: MJPEGConstants.maxScale)
+
+        let quality = max(MJPEGConstants.minQuality, min(MJPEGConstants.maxQuality, CGFloat(qualityPercent) / 100.0))
+        let scale = CGFloat(scalePercent) / 100.0
+
+        logger.info("Starting MJPEG stream: fps=\(fps), quality=\(qualityPercent)%, scale=\(scalePercent)%")
+
+        // Create the MJPEG stream
+        let stream = MJPEGByteStream(fps: fps, quality: quality, scale: scale)
+        let bodySequence = HTTPBodySequence(from: stream)
+
+        // Build response with multipart headers
+        var headers: [HTTPHeader: String] = [:]
+        headers[.contentType] = "multipart/x-mixed-replace; boundary=\(boundary)"
+        headers[HTTPHeader("Server")] = MJPEGConstants.serverName
+        headers[HTTPHeader("Connection")] = "close"
+        headers[HTTPHeader("Cache-Control")] = "no-cache, no-store, must-revalidate"
+        headers[HTTPHeader("Pragma")] = "no-cache"
+        headers[HTTPHeader("Expires")] = "0"
+
+        return HTTPResponse(
+            statusCode: .ok,
+            headers: headers,
+            body: bodySequence
+        )
+    }
+
+    private func parseQueryInt(from request: HTTPRequest, name: String, default defaultValue: Int, min minValue: Int, max maxValue: Int) -> Int {
+        guard let param = request.query.first(where: { $0.name == name }),
+              let intValue = Int(param.value) else {
+            return defaultValue
+        }
+        return Swift.max(minValue, Swift.min(maxValue, intValue))
+    }
+}
+
+/// Async byte sequence that produces MJPEG frame data.
+///
+/// Conforms to `AsyncBufferedSequence<UInt8>` for integration with FlyingFox's
+/// `HTTPBodySequence`. Each buffer yields a complete MJPEG frame including
+/// the multipart boundary, headers, and JPEG image data.
+struct MJPEGByteStream: AsyncBufferedSequence, Sendable {
+    typealias Element = UInt8
+
+    let fps: Int
+    let quality: CGFloat
+    let scale: CGFloat
+
+    init(fps: Int, quality: CGFloat, scale: CGFloat = 1.0) {
+        self.fps = fps
+        self.quality = quality
+        self.scale = scale
+    }
+
+    func makeAsyncIterator() -> MJPEGByteIterator {
+        MJPEGByteIterator(fps: fps, quality: quality, scale: scale)
+    }
+}
+
+/// Iterator that captures screenshots using the fast daemon proxy and yields MJPEG frame bytes.
+final class MJPEGByteIterator: AsyncBufferedIteratorProtocol, @unchecked Sendable {
+    private let fps: Int
+    private let quality: CGFloat
+    private let scale: CGFloat
+
+    private let frameProducer: MJPEGFrameProducer
+    private let metrics: MJPEGMetrics
+
+    private var isCancelled: Bool = false
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: "MJPEGIterator"
+    )
+
+    init(fps: Int, quality: CGFloat, scale: CGFloat) {
+        self.fps = fps
+        self.quality = quality
+        self.scale = scale
+
+        self.metrics = MJPEGMetrics(targetFPS: fps)
+        self.frameProducer = MJPEGFrameProducer(imageScaler: MJPEGImageScaler(), metrics: self.metrics, frameInterval: UInt64(1_000_000_000 / max(1, fps)))
+    }
+
+    func next() async throws -> UInt8? {
+        guard !isCancelled, !Task.isCancelled else { return nil }
+        let buffer = try await nextBuffer(suggested: 1)
+        return buffer?.first
+    }
+
+    func nextBuffer(suggested count: Int) async throws -> [UInt8]? {
+        guard !isCancelled else {
+            metrics.logSummary()
+            return nil
+        }
+
+        if Task.isCancelled {
+            isCancelled = true
+            metrics.logSummary()
+            return nil
+        }
+
+        do {
+            let frameData = try await frameProducer.captureFrame(quality: quality, scale: scale)
+            return Array(frameData)
+        } catch {
+            logger.error("Frame capture error: \(error.localizedDescription)")
+            metrics.logSummary()
+            isCancelled = true
+            return nil
+        }
+    }
+
+}
+

--- a/devicekit-iosUITests/Streamer/MJPEG/MJPEGFrameProducer.swift
+++ b/devicekit-iosUITests/Streamer/MJPEG/MJPEGFrameProducer.swift
@@ -1,0 +1,171 @@
+/// Errors that can occur during MJPEG streaming.
+enum MJPEGFrameError: Error, LocalizedError {
+    case screenshotFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .screenshotFailed:
+            return "Failed to capture screenshot"
+        }
+    }
+}
+
+/// Produces MJPEG-encoded frames from device screenshots, applying optional
+/// scaling and pacing output to a target frame interval.
+///
+/// `FrameProducer` encapsulates the full lifecycle of generating a single
+/// multipart MJPEG frame:
+///   - capturing a screenshot via the XCTest daemon (JPEG-compressed at source)
+///   - optionally scaling the JPEG to reduce resolution
+///   - wrapping the JPEG in a multipart MJPEG boundary with appropriate headers
+///   - recording detailed timing and size metrics
+///   - enforcing a frame interval by sleeping for the remaining budget
+///
+/// This type is designed to be used by higher-level MJPEG streaming components
+/// that repeatedly call `captureFrame(...)` to produce a continuous stream.
+///
+/// The class is intentionally lightweight and stateless aside from metrics
+/// tracking and frame counting.
+final class MJPEGFrameProducer {
+
+    // MARK: - Configuration Constants
+
+    /// MJPEG boundary string used to delimit frames in a multipart response.
+    ///
+    /// This boundary is written before each JPEG payload and must match the
+    /// boundary declared in the HTTP `Content-Type` header of the MJPEG stream.
+    private let boundary = "mjpeg-frame-boundary"
+
+    /// Maximum allowed time for screenshot capture before the operation is
+    /// considered failed.
+    ///
+    /// The screenshot daemon is not real‑time and may stall under load; this
+    /// timeout prevents the pipeline from blocking indefinitely.
+    private let captureTimeout: TimeInterval = 0.5
+
+    /// Number of frames between periodic metrics summary logs.
+    ///
+    /// This helps avoid excessive logging while still providing insight into
+    /// capture performance over time.
+    private let metricsReportInterval: UInt64 = 30
+
+    // MARK: - Dependencies
+
+    /// Component responsible for scaling JPEG data while preserving quality.
+    ///
+    /// Scaling is performed only when the requested scale factor is less than 1.0.
+    private let imageScaler: MJPEGImageScaler
+
+    /// Metrics collector used to record capture time, scaling time, output size,
+    /// and periodic summary logs.
+    private let metrics: MJPEGMetrics
+
+    private let frameInterval: UInt64
+
+    // MARK: - State
+
+    /// Total number of frames produced since initialization.
+    ///
+    /// Used to determine when to emit periodic metrics summaries.
+    private var frameCount: UInt64 = 0
+
+    // MARK: - Initialization
+
+    /// Creates a new frame producer with the given scaler and metrics collector.
+    ///
+    /// - Parameters:
+    ///   - imageScaler: JPEG scaling utility.
+    ///   - metrics: Metrics recorder for capture and output performance.
+    init(imageScaler: MJPEGImageScaler, metrics: MJPEGMetrics, frameInterval: UInt64) {
+        self.imageScaler = imageScaler
+        self.metrics = metrics
+        self.frameInterval = frameInterval
+    }
+
+    // MARK: - Frame Capture
+
+    /// Captures a single MJPEG frame, optionally scales it, wraps it in a
+    /// multipart boundary, records metrics, and enforces a frame interval.
+    ///
+    /// This method must run on the main actor because screenshot capture via
+    /// XCTest daemon APIs is main‑thread‑affine.
+    ///
+    /// - Parameters:
+    ///   - quality: JPEG compression quality in the range `[0.0, 1.0]`.
+    ///   - scale: Optional downscale factor. Values < 1.0 reduce resolution.
+    ///   - frameInterval: Target frame duration in nanoseconds. The method will
+    ///     sleep for the remaining time if capture and processing complete early.
+    ///
+    /// - Returns: A `Data` object containing the full multipart MJPEG frame,
+    ///   including boundary, headers, and JPEG payload.
+    ///
+    /// - Throws: `MJPEGError.screenshotFailed` if screenshot capture fails or
+    ///   times out.
+    @MainActor
+    func captureFrame(
+        quality: Double,
+        scale: CGFloat
+    ) async throws -> Data {
+
+        let startTime = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+
+        // Capture screenshot as JPEG via XCTest daemon.
+        guard var jpegData = try? FBScreenshot.captureJPEG(
+            withQuality: quality,
+            timeout: captureTimeout
+        ) else {
+            metrics.recordCapture(
+                durationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - startTime,
+                success: false
+            )
+            throw MJPEGFrameError.screenshotFailed
+        }
+
+        let captureTime = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        metrics.recordCapture(durationNs: captureTime - startTime, success: true)
+
+        // Apply optional downscaling.
+        if scale < 1.0 {
+            let scaleStart = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+            if let scaledData = imageScaler.scaleJPEG(
+                jpegData,
+                scaleFactor: scale,
+                quality: quality
+            ) {
+                jpegData = scaledData
+                metrics.recordScale(
+                    durationNs: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - scaleStart
+                )
+            }
+        }
+
+        // Construct multipart MJPEG frame.
+        var frameData = Data()
+        let header =
+            "--\(boundary)\r\n" +
+            "Content-Type: image/jpeg\r\n" +
+            "Content-Length: \(jpegData.count)\r\n\r\n"
+
+        frameData.append(Data(header.utf8))
+        frameData.append(jpegData)
+        frameData.append(Data("\r\n".utf8))
+
+        let totalDuration = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - startTime
+        metrics.recordFrameOutput(size: frameData.count, totalDurationNs: totalDuration)
+
+        frameCount += 1
+
+        // Emit periodic metrics summary.
+        if frameCount % metricsReportInterval == 0 {
+            metrics.logSummary()
+        }
+
+        // Enforce frame pacing.
+        let elapsed = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - startTime
+        if elapsed < frameInterval {
+            try await Task.sleep(nanoseconds: frameInterval - elapsed)
+        }
+
+        return frameData
+    }
+}

--- a/devicekit-iosUITests/Streamer/MJPEG/MJPEGImageScaler.swift
+++ b/devicekit-iosUITests/Streamer/MJPEG/MJPEGImageScaler.swift
@@ -1,0 +1,76 @@
+import UniformTypeIdentifiers
+
+/// Utility for scaling images using Core Graphics.
+final class MJPEGImageScaler {
+
+    /// Scales JPEG image data by a given factor.
+    ///
+    /// - Parameters:
+    ///   - data: Original JPEG image data.
+    ///   - scaleFactor: Scale factor (0.0-1.0). 0.5 = 50% of original size.
+    ///   - quality: JPEG compression quality for output (0.0-1.0).
+    /// - Returns: Scaled JPEG data, or nil if scaling failed.
+    func scaleJPEG(_ data: Data, scaleFactor: CGFloat, quality: CGFloat) -> Data? {
+        guard scaleFactor > 0 && scaleFactor < 1.0 else {
+            return data // No scaling needed
+        }
+
+        // Create image source from data
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
+              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+            return nil
+        }
+
+        // Calculate new dimensions
+        let originalWidth = CGFloat(cgImage.width)
+        let originalHeight = CGFloat(cgImage.height)
+        let newWidth = Int(originalWidth * scaleFactor)
+        let newHeight = Int(originalHeight * scaleFactor)
+
+        guard newWidth > 0 && newHeight > 0 else {
+            return nil
+        }
+
+        // Create bitmap context for drawing scaled image
+        guard let context = CGContext(
+            data: nil,
+            width: newWidth,
+            height: newHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        ) else {
+            return nil
+        }
+
+        // Draw scaled image
+        context.interpolationQuality = .medium
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+
+        // Get scaled CGImage
+        guard let scaledCGImage = context.makeImage() else {
+            return nil
+        }
+
+        // Encode as JPEG
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            mutableData as CFMutableData,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return nil
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: quality
+        ]
+        CGImageDestinationAddImage(destination, scaledCGImage, options as CFDictionary)
+        CGImageDestinationFinalize(destination)
+
+        return mutableData as Data
+    }
+}
+

--- a/devicekit-iosUITests/Streamer/MJPEG/MJPEGMetrics.swift
+++ b/devicekit-iosUITests/Streamer/MJPEG/MJPEGMetrics.swift
@@ -1,0 +1,196 @@
+import os
+
+/// Comprehensive metrics collector for MJPEG streaming performance analysis.
+final class MJPEGMetrics: @unchecked Sendable {
+
+    // MARK: - Timing Metrics (all in nanoseconds)
+
+    /// Frame capture times
+    private var captureTimes: [UInt64] = []
+    /// Scaling times (if applicable)
+    private var scaleTimes: [UInt64] = []
+    /// Total frame processing times
+    private var frameTimes: [UInt64] = []
+    /// Time between frame deliveries
+    private var frameIntervals: [UInt64] = []
+
+    // MARK: - Frame Counters
+
+    private(set) var framesCapured: UInt64 = 0
+    private(set) var framesDropped: UInt64 = 0
+    private(set) var framesScaled: UInt64 = 0
+
+    // MARK: - Data Metrics
+
+    private(set) var totalBytesOutput: UInt64 = 0
+    private var frameSizes: [Int] = []
+
+    // MARK: - Session Info
+
+    private let sessionStartTime: UInt64
+    private var lastFrameTime: UInt64 = 0
+    private let targetFPS: Int
+    private let lock = NSLock()
+
+    private let cpuUsageMonitor = CPUUsageMonitor()
+    private let memoryUsageMonitor = MemoryUsageMonitor()
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: "MJPEGMetrics"
+    )
+
+    init(targetFPS: Int) {
+        self.targetFPS = targetFPS
+        self.sessionStartTime = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+    }
+
+    // MARK: - Recording Methods
+
+    func recordCapture(durationNs: UInt64, success: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        if success {
+            captureTimes.append(durationNs)
+            framesCapured += 1
+        } else {
+            framesDropped += 1
+        }
+    }
+
+    func recordScale(durationNs: UInt64) {
+        lock.lock()
+        defer { lock.unlock() }
+        scaleTimes.append(durationNs)
+        framesScaled += 1
+    }
+
+    func recordFrameOutput(size: Int, totalDurationNs: UInt64) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        totalBytesOutput += UInt64(size)
+        frameSizes.append(size)
+        frameTimes.append(totalDurationNs)
+
+        let now = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        if lastFrameTime > 0 {
+            frameIntervals.append(now - lastFrameTime)
+        }
+        lastFrameTime = now
+    }
+
+    // MARK: - Statistics
+
+    private func percentile(_ values: [UInt64], _ p: Double) -> UInt64 {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let index = Int(Double(sorted.count - 1) * p)
+        return sorted[index]
+    }
+
+    private func average(_ values: [UInt64]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        return Double(values.reduce(0, +)) / Double(values.count)
+    }
+
+    func logSummary() {
+        logger.info("\n\(self.generateReport())")
+    }
+
+
+    private func buildSections() -> [ReportSection] {
+        let now = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        let sessionDurationSec = Double(now - sessionStartTime) / 1_000_000_000
+
+        let avgCaptureMs = average(captureTimes) / 1_000_000
+        let avgScaleMs = average(scaleTimes) / 1_000_000
+        let avgFrameMs = average(frameTimes) / 1_000_000
+
+        let p50 = Double(percentile(frameTimes, 0.50)) / 1_000_000
+        let p95 = Double(percentile(frameTimes, 0.95)) / 1_000_000
+        let p99 = Double(percentile(frameTimes, 0.99)) / 1_000_000
+
+        let avgIntervalNs = average(frameIntervals)
+        let actualFPS = avgIntervalNs > 0 ? 1_000_000_000 / avgIntervalNs : 0
+        let fpsEfficiency = actualFPS / Double(targetFPS) * 100
+
+        let throughput = sessionDurationSec > 0 ? Double(framesCapured) / sessionDurationSec : 0
+
+        let dropRate = (framesCapured + framesDropped) > 0
+            ? Double(framesDropped) / Double(framesCapured + framesDropped) * 100
+            : 0
+
+        let bandwidthBps = sessionDurationSec > 0 ? Double(totalBytesOutput * 8) / sessionDurationSec : 0
+        let bandwidthKbps = bandwidthBps / 1000
+        let bandwidthMbps = bandwidthBps / 1_000_000
+
+        let avgFrameSize = frameSizes.isEmpty ? 0 : frameSizes.reduce(0, +) / frameSizes.count
+
+        let memoryMB = Double(memoryUsageMonitor.getMemoryFootprint()) / 1_000_000
+        let cpuUsage = cpuUsageMonitor.cpuUsage()
+
+        let session = ReportSection(
+            title: "Session",
+            metrics: [
+                Metric(name: "Duration", value: .double(sessionDurationSec), unit: "s"),
+                Metric(name: "Frames Captured", value: .uint(framesCapured), unit: nil),
+                Metric(name: "Frames Scaled", value: .uint(framesScaled), unit: nil),
+                Metric(name: "Frames Dropped", value: .uint(framesDropped), unit: nil)
+            ]
+        )
+
+        let timing = ReportSection(
+            title: "Timing (ms)",
+            metrics: [
+                Metric(name: "Capture avg", value: .double(avgCaptureMs), unit: "ms"),
+                Metric(name: "Scale avg", value: .double(avgScaleMs), unit: "ms"),
+                Metric(name: "Frame avg", value: .double(avgFrameMs), unit: "ms"),
+                Metric(name: "Frame p50", value: .double(p50), unit: "ms"),
+                Metric(name: "Frame p95", value: .double(p95), unit: "ms"),
+                Metric(name: "Frame p99", value: .double(p99), unit: "ms")
+            ]
+        )
+
+        let video = ReportSection(
+            title: "Video",
+            metrics: [
+                Metric(name: "Target FPS", value: .int(targetFPS), unit: nil),
+                Metric(name: "Actual FPS", value: .double(actualFPS), unit: nil),
+                Metric(name: "FPS Efficiency", value: .double(fpsEfficiency), unit: "%"),
+                Metric(name: "Throughput", value: .double(throughput), unit: " frames/sec"),
+                Metric(name: "Drop Rate", value: .double(dropRate), unit: "%")
+            ]
+        )
+
+        let bandwidth = ReportSection(
+            title: "Bandwidth",
+            metrics: [
+                Metric(name: "Rate", value: .double(bandwidthMbps), unit: " Mbps"),
+                Metric(name: "Rate (kbps)", value: .double(bandwidthKbps), unit: " kbps"),
+                Metric(name: "Total Data", value: .double(Double(totalBytesOutput) / 1_000_000), unit: " MB"),
+                Metric(name: "Avg Frame Size", value: .int(avgFrameSize), unit: " bytes")
+            ]
+        )
+
+        let system = ReportSection(
+            title: "System",
+            metrics: [
+                Metric(name: "Memory", value: .double(memoryMB), unit: " MB"),
+                Metric(name: "CPU", value: .double(cpuUsage), unit: "%")
+            ]
+        )
+
+        return [session, timing, video, bandwidth, system]
+    }
+
+    func generateReport() -> String {
+        let sections = buildSections()
+
+        return AsciiReportRenderer().render(
+            sections: sections,
+            title: "MJPEG STREAM METRICS REPORT"
+        )
+    }
+
+}

--- a/devicekit-iosUITests/Utilities/FBScreenshot.h
+++ b/devicekit-iosUITests/Utilities/FBScreenshot.h
@@ -1,0 +1,89 @@
+/**
+ * @file FBScreenshot.h
+ * @brief Fast screenshot capture using XCTest daemon proxy.
+ *
+ * Provides fast screenshot capture by directly communicating with the
+ * XCTest daemon, bypassing the slower XCUIScreen.screenshot() API.
+ */
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKey.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * @class FBScreenshot
+ * @brief Utility class for fast screenshot capture.
+ *
+ * Uses the XCTest daemon proxy to capture screenshots with JPEG compression
+ * at the source level for optimal performance in streaming scenarios.
+ */
+@interface FBScreenshot : NSObject
+
+/**
+ * Captures a JPEG screenshot from the main screen.
+ *
+ * @param quality JPEG compression quality (0.0 - 1.0). Lower values = smaller
+ * size.
+ * @param timeout Maximum time to wait for screenshot capture in seconds.
+ * @param error On return, contains an error if the capture failed.
+ * @return JPEG image data, or nil if capture failed.
+ */
++ (nullable NSData *)captureJPEGWithQuality:(double)quality
+                                    timeout:(NSTimeInterval)timeout
+                                      error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Captures a JPEG screenshot from a specific screen.
+ *
+ * @param screenID The display ID of the screen to capture.
+ * @param quality JPEG compression quality (0.0 - 1.0).
+ * @param timeout Maximum time to wait for screenshot capture in seconds.
+ * @param error On return, contains an error if the capture failed.
+ * @return JPEG image data, or nil if capture failed.
+ */
++ (nullable NSData *)captureJPEGWithScreenID:(long long)screenID
+                                     quality:(double)quality
+                                     timeout:(NSTimeInterval)timeout
+                                       error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Captures a screenshot from a specific screen and returns it as a UIImage.
+ *
+ * @param quality JPEG compression quality (0.0 – 1.0). Used only when the
+ *                underlying screenshot request encodes JPEG data.
+ * @param timeout Maximum time to wait for screenshot capture, in seconds.
+ * @param error   On return, contains an error if the capture failed.
+ *
+ * @return A UIImage representing the captured screenshot, or nil
+ *         if the capture failed or timed out.
+ */
++ (nullable UIImage *)captureUIImageWithQuality:(double)quality
+                                        timeout:(NSTimeInterval)timeout
+                                          error:(NSError *_Nullable *_Nullable)error;
+
+/**
+ * Captures a lossless PNG screenshot from the main screen.
+ *
+ * This method is preferred for H.264 encoding as it provides better source
+ * quality compared to JPEG (no compression artifacts).
+ *
+ * @param timeout Maximum time to wait for screenshot capture, in seconds.
+ * @param error   On return, contains an error if the capture failed.
+ *
+ * @return A UIImage representing the captured screenshot in PNG format, or nil
+ *         if the capture failed or timed out.
+ */
++ (nullable UIImage *)capturePNGImageWithTimeout:(NSTimeInterval)timeout
+                                           error:(NSError *_Nullable *_Nullable)error;
+/**
+ * Returns the display ID of the main screen.
+ *
+ * @return The main screen's display ID.
+ */
++ (long long)mainScreenDisplayID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/devicekit-iosUITests/Utilities/FBScreenshot.m
+++ b/devicekit-iosUITests/Utilities/FBScreenshot.m
@@ -1,0 +1,304 @@
+/**
+ * @file FBScreenshot.m
+ * @brief Implementation of fast screenshot capture using modern XCTest API.
+ */
+
+#import "FBScreenshot.h"
+#import "FBLogger.h"
+#import "XCTestDaemonsProxy.h"
+#import "XCTestManager_ManagerInterface-Protocol.h"
+#import "XCUIScreen.h"
+#import <objc/message.h>
+
+@import UniformTypeIdentifiers;
+
+@implementation FBScreenshot
+
++ (nullable NSData *)captureJPEGWithQuality:(double)quality
+                                    timeout:(NSTimeInterval)timeout
+                                      error:(NSError *_Nullable *_Nullable)error
+{
+    long long screenID = [self mainScreenDisplayID];
+    return [self captureJPEGWithScreenID:screenID
+                                 quality:quality
+                                 timeout:timeout
+                                   error:error];
+}
+
++ (nullable UIImage *)captureUIImageWithQuality:(double)quality
+                                        timeout:(NSTimeInterval)timeout
+                                          error:(NSError *_Nullable *_Nullable)error
+{
+    long long screenID = [self mainScreenDisplayID];
+    return [self captureUIImageWithScreenID:screenID
+                                    quality:quality
+                                    timeout:timeout
+                                      error:error];
+}
+
++ (nullable UIImage *)capturePNGImageWithTimeout:(NSTimeInterval)timeout
+                                           error:(NSError *_Nullable *_Nullable)error
+{
+    long long screenID = [self mainScreenDisplayID];
+    return [self captureUIImageWithScreenID:screenID
+                                        uti:UTTypePNG
+                         compressionQuality:1.0
+                                    timeout:timeout
+                                      error:error];
+}
+
++ (nullable UIImage *)captureUIImageWithScreenID:(long long)screenID
+                                         quality:(double)quality
+                                         timeout:(NSTimeInterval)timeout
+                                           error:(NSError *_Nullable *_Nullable)error
+{
+    return [self captureUIImageWithScreenID:screenID
+                                        uti:UTTypeJPEG
+                         compressionQuality:quality
+                                    timeout:timeout
+                                      error:error];
+}
+
++ (nullable UIImage *)captureUIImageWithScreenID:(long long)screenID
+                                             uti:(UTType *)uti
+                              compressionQuality:(double)compressionQuality
+                                         timeout:(NSTimeInterval)timeout
+                                           error:(NSError *_Nullable *_Nullable)error
+{
+    // Start timing
+    uint64_t startTime = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
+
+    // Create screenshot request using modern API
+    id screenshotRequest = [self screenshotRequestWithScreenID:screenID
+                                                          rect:CGRectNull
+                                                           uti:uti
+                                            compressionQuality:compressionQuality
+                                                         error:error];
+    if (nil == screenshotRequest) {
+        return nil;
+    }
+
+    id<XCTestManager_ManagerInterface> proxy = [XCTestDaemonsProxy testRunnerProxy];
+
+    __block UIImage *uiImage = nil;
+    __block NSError *innerError = nil;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    // Use modern API: _XCT_requestScreenshot:withReply:
+    [proxy _XCT_requestScreenshot:screenshotRequest
+                        withReply:^(id image, NSError *err) {
+        if (err != nil) {
+            innerError = err;
+        } else if (image != nil) {
+            if ([image respondsToSelector:@selector(platformImage)]) {
+                uiImage = [image performSelector:@selector(platformImage)];
+            }
+        }
+        dispatch_semaphore_signal(semaphore);
+    }];
+
+    // Wait with timeout
+    int64_t timeoutNs = (int64_t)(timeout * NSEC_PER_SEC);
+    if (dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, timeoutNs)) != 0) {
+        if (error != nil) {
+            *error = [NSError errorWithDomain:@"FBScreenshot"
+                                         code:1
+                                     userInfo:@{
+                                         NSLocalizedDescriptionKey: @"Screenshot capture timed out"
+                                     }];
+        }
+        [FBLogger logFmt:@"Screenshot capture timed out after %.2fs", timeout];
+        return nil;
+    }
+
+    if (innerError != nil) {
+        if (error != nil) {
+            *error = innerError;
+        }
+        [FBLogger logFmt:@"Screenshot capture failed: %@", innerError.localizedDescription];
+        return nil;
+    }
+
+    // Log timing
+    uint64_t elapsedNs = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - startTime;
+    double elapsedMs = (double)elapsedNs / 1000000.0;
+    CGSize size = uiImage.size;
+
+    return uiImage;
+}
+
++ (nullable NSData *)captureJPEGWithScreenID:(long long)screenID
+                                     quality:(double)quality
+                                     timeout:(NSTimeInterval)timeout
+                                       error:(NSError *_Nullable *_Nullable)error
+{
+    // Start timing
+    uint64_t startTime = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
+
+    // Create screenshot request using modern API
+    id screenshotRequest = [self screenshotRequestWithScreenID:screenID
+                                                          rect:CGRectNull
+                                                           uti:UTTypeJPEG
+                                            compressionQuality:quality
+                                                         error:error];
+    if (nil == screenshotRequest) {
+        return nil;
+    }
+
+    id<XCTestManager_ManagerInterface> proxy = [XCTestDaemonsProxy testRunnerProxy];
+
+    __block NSData *screenshotData = nil;
+    __block NSError *innerError = nil;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    // Use modern API: _XCT_requestScreenshot:withReply:
+    [proxy _XCT_requestScreenshot:screenshotRequest
+                        withReply:^(id image, NSError *err) {
+        if (err != nil) {
+            innerError = err;
+        } else if (image != nil) {
+            // XCTImage has a 'data' property that returns NSData
+            if ([image respondsToSelector:@selector(data)]) {
+                screenshotData = [image performSelector:@selector(data)];
+            }
+        }
+        dispatch_semaphore_signal(semaphore);
+    }];
+
+    // Wait with timeout
+    int64_t timeoutNs = (int64_t)(timeout * NSEC_PER_SEC);
+    if (dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, timeoutNs)) != 0) {
+        if (error != nil) {
+            *error = [NSError errorWithDomain:@"FBScreenshot"
+                                         code:1
+                                     userInfo:@{
+                                         NSLocalizedDescriptionKey: @"Screenshot capture timed out"
+                                     }];
+        }
+        [FBLogger logFmt:@"Screenshot capture timed out after %.2fs", timeout];
+        return nil;
+    }
+
+    if (innerError != nil) {
+        if (error != nil) {
+            *error = innerError;
+        }
+        [FBLogger logFmt:@"Screenshot capture failed: %@", innerError.localizedDescription];
+        return nil;
+    }
+
+    // Log timing
+    uint64_t elapsedNs = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - startTime;
+    double elapsedMs = (double)elapsedNs / 1000000.0;
+    NSUInteger dataSize = screenshotData.length;
+
+    return screenshotData;
+}
+
++ (long long)mainScreenDisplayID
+{
+    return XCUIScreen.mainScreen.displayID;
+}
+
+#pragma mark - Private Methods
+
+/**
+ * Creates an XCTImageEncoding object for the specified format and quality.
+ */
++ (nullable id)imageEncodingWithUniformTypeIdentifier:(UTType *)uti
+                                   compressionQuality:(CGFloat)compressionQuality
+                                                error:(NSError **)error
+{
+    Class imageEncodingClass = NSClassFromString(@"XCTImageEncoding");
+    if (nil == imageEncodingClass) {
+        if (error != nil) {
+            *error = [NSError errorWithDomain:@"FBScreenshot"
+                                         code:2
+                                     userInfo:@{
+                                         NSLocalizedDescriptionKey: @"Cannot find XCTImageEncoding class"
+                                     }];
+        }
+        return nil;
+    }
+
+    id imageEncodingAllocated = [imageEncodingClass alloc];
+    SEL imageEncodingConstructorSelector = NSSelectorFromString(@"initWithUniformTypeIdentifier:compressionQuality:");
+    if (![imageEncodingAllocated respondsToSelector:imageEncodingConstructorSelector]) {
+        if (error != nil) {
+            *error = [NSError errorWithDomain:@"FBScreenshot"
+                                         code:3
+                                     userInfo:@{
+                                         NSLocalizedDescriptionKey: @"XCTImageEncoding constructor not found"
+                                     }];
+        }
+        return nil;
+    }
+
+    NSMethodSignature *signature = [imageEncodingAllocated methodSignatureForSelector:imageEncodingConstructorSelector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setSelector:imageEncodingConstructorSelector];
+    NSString *utiIdentifier = uti.identifier;
+    [invocation setArgument:&utiIdentifier atIndex:2];
+    [invocation setArgument:&compressionQuality atIndex:3];
+    [invocation invokeWithTarget:imageEncodingAllocated];
+
+    id __unsafe_unretained imageEncoding;
+    [invocation getReturnValue:&imageEncoding];
+    return imageEncoding;
+}
+
+/**
+ * Creates an XCTScreenshotRequest object for the specified parameters.
+ */
++ (nullable id)screenshotRequestWithScreenID:(long long)screenID
+                                        rect:(CGRect)rect
+                                         uti:(UTType *)uti
+                          compressionQuality:(CGFloat)compressionQuality
+                                       error:(NSError **)error
+{
+    id imageEncoding = [self imageEncodingWithUniformTypeIdentifier:uti
+                                                 compressionQuality:compressionQuality
+                                                              error:error];
+    if (nil == imageEncoding) {
+        return nil;
+    }
+
+    Class screenshotRequestClass = NSClassFromString(@"XCTScreenshotRequest");
+    if (nil == screenshotRequestClass) {
+        if (error != nil) {
+            *error = [NSError errorWithDomain:@"FBScreenshot"
+                                         code:4
+                                     userInfo:@{
+                                         NSLocalizedDescriptionKey: @"Cannot find XCTScreenshotRequest class"
+                                     }];
+        }
+        return nil;
+    }
+
+    id screenshotRequestAllocated = [screenshotRequestClass alloc];
+    SEL constructorSelector = NSSelectorFromString(@"initWithScreenID:rect:encoding:");
+    if (![screenshotRequestAllocated respondsToSelector:constructorSelector]) {
+        if (error != nil) {
+            *error = [NSError errorWithDomain:@"FBScreenshot"
+                                         code:5
+                                     userInfo:@{
+                                         NSLocalizedDescriptionKey: @"XCTScreenshotRequest constructor not found"
+                                     }];
+        }
+        return nil;
+    }
+
+    NSMethodSignature *signature = [screenshotRequestAllocated methodSignatureForSelector:constructorSelector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setSelector:constructorSelector];
+    [invocation setArgument:&screenID atIndex:2];
+    [invocation setArgument:&rect atIndex:3];
+    [invocation setArgument:&imageEncoding atIndex:4];
+    [invocation invokeWithTarget:screenshotRequestAllocated];
+
+    id __unsafe_unretained screenshotRequest;
+    [invocation getReturnValue:&screenshotRequest];
+    return screenshotRequest;
+}
+
+@end

--- a/devicekit-iosUITests/XCTestServer.swift
+++ b/devicekit-iosUITests/XCTestServer.swift
@@ -10,7 +10,7 @@ extension String {
     }
 }
 
-// MARK: - WebSocket JSON-RPC Server
+// MARK: - WebSocket HTTP & JSON-RPC Server
 
 /// WebSocket server with JSON-RPC 2.0 protocol for UI automation.
 ///
@@ -24,7 +24,7 @@ extension String {
 ///
 /// ## Starting the Server
 /// ```swift
-/// let server = XCTestWebSocketServer()
+/// let server = XCTestServer()
 /// try await server.start()  // Blocks until shutdown
 /// ```
 ///
@@ -67,7 +67,7 @@ extension String {
 /// };
 /// ```
 @MainActor
-final class XCTestWebSocketServer {
+final class XCTestServer {
 
     /// Default timeout for WebSocket operations.
     private let defaultTimeout: TimeInterval = 100
@@ -80,7 +80,7 @@ final class XCTestWebSocketServer {
 
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!,
-        category: "XCTestWebSocketServer"
+        category: "XCTestServer"
     )
 
     /// JSON-RPC dispatcher for routing method calls.
@@ -121,7 +121,15 @@ final class XCTestWebSocketServer {
             HTTPResponse(statusCode: .ok, body: Data("OK".utf8))
         }
 
-        logger.info("Server is ready (WebSocket: ws://\(self.localhost):\(port)/rpc, HTTP: POST http://\(self.localhost):\(port)/rpc)")
+        // MJPEG streaming endpoint
+        let mjpegHandler = MJPEGHTTPHandler()
+        await server.appendRoute("GET /mjpeg", to: mjpegHandler)
+
+        // H264 streaming endpoint
+        let h264Handler = H264HTTPHandler()
+        await server.appendRoute("GET /h264", to: h264Handler)
+
+        logger.info("Server is ready (WebSocket: ws://\(self.localhost):\(port)/rpc, HTTP: POST http://\(self.localhost):\(port)/rpc, MJPEG: http://\(self.localhost):\(port)/mjpeg, H264: http://\(self.localhost):\(port)/h264)")
         try await server.run()
     }
 }

--- a/devicekit-iosUITests/devicekit_iosUITests.swift
+++ b/devicekit-iosUITests/devicekit_iosUITests.swift
@@ -27,7 +27,7 @@ final class devicekit_iosUITests: XCTestCase {
 
     @MainActor
     func testRunAutomation() async throws {
-        let server = XCTestWebSocketServer()
+        let server = XCTestServer()
         devicekit_iosUITests.logger.info("Will start WebSocket JSON-RPC server")
         try await server.start()
     }

--- a/h264-codec/Sources/h264-codec/CGImage+Extension.swift
+++ b/h264-codec/Sources/h264-codec/CGImage+Extension.swift
@@ -1,0 +1,143 @@
+import CoreGraphics
+import CoreImage
+import CoreVideo
+
+/// Extensions for creating `CVPixelBuffer` from `CGImage` using GPU-accelerated Core Image.
+///
+/// This extension provides efficient pixel buffer creation by using `CIContext.render()`
+/// instead of CPU-bound `CGContext.draw()`.
+///
+/// ## Performance
+/// - GPU-accelerated rendering via Metal (when available)
+/// - Significantly faster than CGContext.draw() for large images
+/// - Supports pixel buffer pooling for memory efficiency
+///
+/// ## Usage
+/// ```swift
+/// let context = CIContext(options: [.useSoftwareRenderer: false])
+/// let pixelBuffer = cgImage.toPixelBuffer(context: context, size: targetSize)
+/// ```
+extension CGImage {
+
+    /// Creates a `CVPixelBuffer` from this CGImage using GPU-accelerated Core Image rendering.
+    ///
+    /// - Parameters:
+    ///   - context: A `CIContext` for GPU rendering. Reuse this across frames for efficiency.
+    ///   - targetSize: The output pixel buffer size. If different from the image size, the image is scaled.
+    ///   - pixelFormat: The pixel format for the buffer. Defaults to 32-bit BGRA.
+    ///   - pool: Optional pixel buffer pool for memory efficiency. If nil, a new buffer is allocated.
+    /// - Returns: A `CVPixelBuffer` containing the rendered image, or `nil` on failure.
+    ///
+    /// ## Behavior
+    /// - Creates a `CIImage` from this `CGImage`
+    /// - Applies scaling transform if `targetSize` differs from image size
+    /// - Renders to a `CVPixelBuffer` using GPU-accelerated `CIContext.render()`
+    ///
+    /// ## Performance Notes
+    /// - Reuse the `CIContext` across multiple frames to avoid creation overhead
+    /// - Use a `CVPixelBufferPool` for repeated conversions to reduce memory allocation
+    /// - The Metal backend is used automatically when available
+    public func toPixelBuffer(
+        context: CIContext,
+        targetSize: CGSize? = nil,
+        pixelFormat: OSType = kCVPixelFormatType_32BGRA,
+        pool: CVPixelBufferPool? = nil
+    ) -> CVPixelBuffer? {
+        // Create CIImage from CGImage
+        var ciImage = CIImage(cgImage: self)
+
+        // Determine output size
+        let outputSize = targetSize ?? CGSize(width: width, height: height)
+
+        // Apply scaling if needed
+        let scaleX = outputSize.width / ciImage.extent.width
+        let scaleY = outputSize.height / ciImage.extent.height
+        if abs(scaleX - 1.0) > 0.001 || abs(scaleY - 1.0) > 0.001 {
+            ciImage = ciImage.transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
+        }
+
+        // Get or create pixel buffer
+        var pixelBuffer: CVPixelBuffer?
+
+        if let pool = pool {
+            // Allocate from pool
+            let status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
+            if status != kCVReturnSuccess {
+                return nil
+            }
+        } else {
+            // Create new pixel buffer with IOSurface backing for GPU compatibility
+            let attributes: [String: Any] = [
+                kCVPixelBufferPixelFormatTypeKey as String: pixelFormat,
+                kCVPixelBufferWidthKey as String: Int(outputSize.width),
+                kCVPixelBufferHeightKey as String: Int(outputSize.height),
+                kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+                kCVPixelBufferMetalCompatibilityKey as String: true
+            ]
+
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                Int(outputSize.width),
+                Int(outputSize.height),
+                pixelFormat,
+                attributes as CFDictionary,
+                &pixelBuffer
+            )
+
+            if status != kCVReturnSuccess {
+                return nil
+            }
+        }
+
+        guard let buffer = pixelBuffer else { return nil }
+
+        // GPU-accelerated render from CIImage to CVPixelBuffer
+        context.render(ciImage, to: buffer)
+
+        return buffer
+    }
+
+    /// Creates a `CVPixelBufferPool` suitable for this image's dimensions.
+    ///
+    /// - Parameters:
+    ///   - size: The dimensions for buffers in the pool.
+    ///   - pixelFormat: The pixel format for buffers. Defaults to 32-bit BGRA.
+    ///   - minimumBufferCount: Minimum number of buffers to keep in the pool.
+    /// - Returns: A configured `CVPixelBufferPool`, or `nil` on failure.
+    ///
+    /// ## Usage
+    /// Create a pool once and reuse it for all frame conversions:
+    /// ```swift
+    /// let pool = CGImage.createPixelBufferPool(size: targetSize, minimumBufferCount: 6)
+    /// for image in frames {
+    ///     let buffer = image.toPixelBuffer(context: ciContext, targetSize: targetSize, pool: pool)
+    /// }
+    /// ```
+    public static func createPixelBufferPool(
+        size: CGSize,
+        pixelFormat: OSType = kCVPixelFormatType_32BGRA,
+        minimumBufferCount: Int = 6
+    ) -> CVPixelBufferPool? {
+        let poolAttributes: [String: Any] = [
+            kCVPixelBufferPoolMinimumBufferCountKey as String: minimumBufferCount
+        ]
+
+        let pixelBufferAttributes: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: pixelFormat,
+            kCVPixelBufferWidthKey as String: Int(size.width),
+            kCVPixelBufferHeightKey as String: Int(size.height),
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+            kCVPixelBufferMetalCompatibilityKey as String: true
+        ]
+
+        var pool: CVPixelBufferPool?
+        let status = CVPixelBufferPoolCreate(
+            kCFAllocatorDefault,
+            poolAttributes as CFDictionary,
+            pixelBufferAttributes as CFDictionary,
+            &pool
+        )
+
+        return status == kCVReturnSuccess ? pool : nil
+    }
+}

--- a/h264-codec/Sources/h264-codec/H264Encoder.swift
+++ b/h264-codec/Sources/h264-codec/H264Encoder.swift
@@ -1,7 +1,9 @@
 import Accelerate
+import CoreGraphics
+import CoreImage
 import CoreMedia
+import CoreVideo
 import VideoToolbox
-import UIKit
 
 /// A hardware‑accelerated H.264 encoder built on VideoToolbox.
 ///
@@ -411,5 +413,76 @@ public final class H264Encoder: NSObject {
             sourceFrameRefcon: nil,
             infoFlagsOut: nil
         )
+    }
+
+    /// Encodes a raw `CVPixelBuffer` directly without rotation.
+    ///
+    /// - Parameters:
+    ///   - pixelBuffer: The pixel buffer to encode (must match encoder dimensions).
+    ///   - timestamp: Presentation timestamp for the encoded frame.
+    ///
+    /// Use this method when the pixel buffer is already in the correct orientation
+    /// and size, such as when converting from screenshots that don't need rotation.
+    ///
+    /// ## Important Notes
+    /// - The pixel buffer dimensions must match the encoder's configured dimensions.
+    /// - No rotation or scaling is applied.
+    /// - Uses `CMTime.invalid` as duration.
+    public func encode(
+        pixelBuffer: CVPixelBuffer,
+        timestamp: CMTime
+    ) {
+        guard let session = session else { return }
+
+        VTCompressionSessionEncodeFrame(
+            session,
+            imageBuffer: pixelBuffer,
+            presentationTimeStamp: timestamp,
+            duration: CMTime.invalid,
+            frameProperties: nil,
+            sourceFrameRefcon: nil,
+            infoFlagsOut: nil
+        )
+    }
+
+    /// Encodes a `CGImage` by converting it to a pixel buffer using GPU-accelerated Core Image.
+    ///
+    /// - Parameters:
+    ///   - cgImage: The source CGImage to encode.
+    ///   - timestamp: Presentation timestamp for the encoded frame.
+    ///   - context: The `CIContext` used for GPU-accelerated rendering.
+    ///   - targetSize: Optional target size. If nil, uses CGImage dimensions.
+    ///   - pool: Optional pixel buffer pool for memory efficiency.
+    ///
+    /// This method:
+    /// - Converts the CGImage to a CVPixelBuffer using GPU-accelerated `CIContext.render()`.
+    /// - Encodes the pixel buffer via `VTCompressionSessionEncodeFrame`.
+    ///
+    /// ## Performance
+    /// - Uses GPU for pixel buffer creation (faster than CGContext.draw)
+    /// - Reuse the CIContext and pool across frames for best performance
+    ///
+    /// ## Usage
+    /// ```swift
+    /// let context = CIContext(options: [.useSoftwareRenderer: false])
+    /// let pool = CGImage.createPixelBufferPool(size: targetSize)
+    /// encoder.encode(cgImage: image, timestamp: time, context: context, pool: pool)
+    /// ```
+    public func encode(
+        cgImage: CGImage,
+        timestamp: CMTime,
+        context: CIContext,
+        targetSize: CGSize? = nil,
+        pool: CVPixelBufferPool? = nil
+    ) {
+        guard let pixelBuffer = cgImage.toPixelBuffer(
+            context: context,
+            targetSize: targetSize,
+            pool: pool
+        ) else {
+            return
+        }
+
+        encode(pixelBuffer: pixelBuffer, timestamp: timestamp)
     }
 }

--- a/tcp/Sources/tcp/TCPServer.swift
+++ b/tcp/Sources/tcp/TCPServer.swift
@@ -51,6 +51,15 @@ public final class TCPServer {
     /// This handler is called on `connectionQueue`, not the main thread.
     public var messageHandler: ((Data) -> Void)?
 
+    /// A callback invoked when a new client connects.
+    ///
+    /// This closure is called when a connection reaches `.ready` state.
+    /// Use this to perform initialization such as sending cached data to the client.
+    ///
+    /// ## Important
+    /// This handler is called on `connectionQueue`, not the main thread.
+    public var onClientConnected: (() -> Void)?
+
     /// Creates a new TCP server instance.
     public init() {}
 
@@ -100,6 +109,9 @@ public final class TCPServer {
 
                     // Start receiving data from the connection
                     weakSelf.startReceiving(on: connection)
+
+                    // Notify that a client has connected
+                    weakSelf.onClientConnected?()
                 }
 
                 // Potential improvement:
@@ -124,6 +136,7 @@ public final class TCPServer {
         listener = nil
         dataHandler = nil
         messageHandler = nil
+        onClientConnected = nil
     }
 
     /// Starts receiving data from the connection.


### PR DESCRIPTION
To Run MJPEG:
in the browser call `http://127.0.0.1:12004/mjpeg?fps=30&quality=25`



https://github.com/user-attachments/assets/eb34d8cb-2cfa-4676-afe8-47efcb953174

with ffplay:
`ffplay "http://127.0.0.1:12004/mjpeg?fps=30"` 


To Run H264:
`curl http://127.0.0.1:12004/h264 | ffplay -probesize 32 -analyzeduration 0 -fflags nobuffer -flags low_delay -f h264 -`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * H.264 streaming over HTTP with configurable FPS, bitrate and quality.
  * MJPEG browser-friendly streaming with quality/scale options.
  * Fast screenshot API (JPEG/PNG/UIImage) with timeout support.
  * In-test CPU & memory monitors and runtime metrics reporting (ASCII reports).

* **Documentation**
  * Expanded streaming docs: multiple methods, quick starts, examples, comparison and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->