### PR TITLE
docs: update README installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ cd devicekit-ios
 # Install dependencies
 brew install xcbeautify
 
-# Fetch git submodules
-git submodule update --init --recursive
-
 # Build unsigned IPA for real devices
 make ipa-unsigned
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Control any iOS device or simulator over a simple JSON-RPC API. Tap, swipe, stre
 git clone https://github.com/mobile-next/devicekit-ios.git
 cd devicekit-ios
 
+# Install dependencies
+brew install xcbeautify
+
+# Fetch git submodules
+git submodule update --init --recursive
+
 # Build unsigned IPA for real devices
 make ipa-unsigned
 
@@ -74,7 +80,7 @@ Once the server is running at `127.0.0.1:12004`, make your first call:
 ```bash
 curl -X POST http://127.0.0.1:12004/rpc \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"device.screenshot","params":{},"id":1}'
+  -d '{"jsonrpc":"2.0","method":"device.screenshot","params":{ "format": "jpg" },"id":1}'
 ```
 
 Returns a base64-encoded PNG of the current screen.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Once the server is running at `127.0.0.1:12004`, make your first call:
 ```bash
 curl -X POST http://127.0.0.1:12004/rpc \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"device.screenshot","params":{ "format": "jpg" },"id":1}'
+  -d '{"jsonrpc":"2.0","method":"device.screenshot","params":{ "format": "png" },"id":1}'
 ```
 
 Returns a base64-encoded PNG of the current screen.


### PR DESCRIPTION
# Summary
- Clarify `xcbeautify` as a required dependency for building devicekit-ios.
- Ensure git submodules are initialized during setup (required for Opus).
- Updated **Quick Start** step to include parameters for `device.screenshot`.