### PR TITLE
chore: update changelog for 0.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.19](https://github.com/mobile-next/devicekit-ios/releases/tag/0.0.19) (2026-06-14)
+* Refactor: Split H264 streaming code out into a separate repository ([#47](https://github.com/mobile-next/devicekit-ios/pull/47), [#46](https://github.com/mobile-next/devicekit-ios/pull/46))
+* Test: Migrate test suite from Mocha to Playwright ([#49](https://github.com/mobile-next/devicekit-ios/pull/49))
+
 ## [0.0.18](https://github.com/mobile-next/devicekit-ios/releases/tag/0.0.18) (2026-05-04)
 * Fix: Prevent XCTest from resetting shouldHaltWhenReceivesControl back to YES on setup
 


### PR DESCRIPTION
Update CHANGELOG.md with the 0.0.19 release entry.

* Refactor: Split H264 streaming code out into a separate repository (#47, #46)
* Test: Migrate test suite from Mocha to Playwright (#49)