### PR TITLE
fix: resolve nested window offsets for widget elements in dump ui

### DIFF
--- a/DeviceKitTests/JSONRPC/Handlers/DumpUI.swift
+++ b/DeviceKitTests/JSONRPC/Handlers/DumpUI.swift
@@ -285,6 +285,6 @@ struct DumpUIMethodHandler: RPCMethodHandler {
 
     private func elementHierarchy(xcuiElement: XCUIElement) throws -> AXElement {
         let snapshotDictionary = try xcuiElement.snapshot().dictionaryRepresentation
-        return AXElement(snapshotDictionary)
+        return AXElement(snapshotDictionary).resolvingNestedWindowOffsets()
     }
 }

--- a/DeviceKitTests/XCTest/AXElement.swift
+++ b/DeviceKitTests/XCTest/AXElement.swift
@@ -212,4 +212,64 @@ struct AXElement: Codable {
 
         return max ?? 1
     }
+
+    // XCTest reports frames relative to the screen, except when an element is hosted in a
+    // nested window (e.g. a WidgetKit extension) - there, frames reset to be relative to that
+    // window's own origin. windowContextID marks the boundary: fix it up by re-basing the
+    // subtree's frames onto where the parent element already placed it on screen.
+    // windowContextID == 0 shows up on placeholder/group nodes with no real window of their
+    // own, so only a nonzero-to-different-nonzero transition counts as a real boundary.
+    func resolvingNestedWindowOffsets(
+        parentWindowContextID: Double? = nil,
+        parentResolvedFrame: AXFrame? = nil,
+        inheritedOffsetX: Double = 0,
+        inheritedOffsetY: Double = 0
+    ) -> AXElement {
+        var offsetX = inheritedOffsetX
+        var offsetY = inheritedOffsetY
+        if let parentWindowContextID, parentWindowContextID != 0,
+           windowContextID != 0, windowContextID != parentWindowContextID,
+           let parentResolvedFrame {
+            // Crossing into a nested window: its frames are relative to its own origin, not
+            // the parent's. Compute a fresh offset that rebases this node onto the
+            // screen-absolute position the parent already resolved, and carry that same
+            // offset down to every descendant still inside this window.
+            offsetX = (parentResolvedFrame["X"] ?? 0) - (frame["X"] ?? 0)
+            offsetY = (parentResolvedFrame["Y"] ?? 0) - (frame["Y"] ?? 0)
+        }
+
+        let resolvedFrame: AXFrame = [
+            "X": (frame["X"] ?? 0) + offsetX,
+            "Y": (frame["Y"] ?? 0) + offsetY,
+            "Width": frame["Width"] ?? 0,
+            "Height": frame["Height"] ?? 0,
+        ]
+
+        let resolvedChildren = children?.map {
+            $0.resolvingNestedWindowOffsets(
+                parentWindowContextID: windowContextID,
+                parentResolvedFrame: resolvedFrame,
+                inheritedOffsetX: offsetX,
+                inheritedOffsetY: offsetY
+            )
+        }
+
+        return AXElement(
+            identifier: identifier,
+            frame: resolvedFrame,
+            value: value,
+            title: title,
+            label: label,
+            elementType: elementType,
+            enabled: enabled,
+            horizontalSizeClass: horizontalSizeClass,
+            verticalSizeClass: verticalSizeClass,
+            placeholderValue: placeholderValue,
+            selected: selected,
+            hasFocus: hasFocus,
+            displayID: displayID,
+            windowContextID: windowContextID,
+            children: resolvedChildren
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- `device.dump.ui` reported wrong screen coordinates for elements hosted inside a nested window (e.g. a home screen widget's WidgetKit extension) — frames came back relative to that window's own origin instead of the screen, since XCTest's snapshot frame is only screen-absolute up to the point where `windowContextID` changes.
- Added `AXElement.resolvingNestedWindowOffsets()`, which walks the tree and, on a nonzero-to-different-nonzero `windowContextID` transition, rebases that subtree's frames onto the screen-absolute position the parent already resolved — carrying the same offset through every descendant still inside that window.
- Wired into `DumpUI.swift`'s `elementHierarchy`.

## Root cause
Confirmed via `raw` format dump of a home screen with a Calendar widget: the widget's date label reported `x=17.67, y=27.99` (relative to the widget's own WidgetKit extension window), while the widget itself sits at `x=204, y=67` on screen. Also confirmed this is not something WebDriverAgent/Appium handles correctly either — same bug reproduces there.

## Test plan
- [x] Verified live against a booted simulator: with the fix, the widget's date label resolves to `x=221.67, y=95.0`, matching the hand-computed expected screen position (`204+17.67`, `67+28`).
- [x] Confirmed non-widget elements are unaffected (offset stays 0 when `windowContextID` never changes).

Related: mobile-next/mobilewright#238