### PR TITLE
build: ship main app ipa (devicekit-ios.ipa) in releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  sim-zip-arm64    Build XCUITest runner zip for iOS Simulator (arm64 / Apple Silicon)"
 	@echo "  sim-zip-x86_64   Build XCUITest runner zip for iOS Simulator (x86_64 / Intel)"
 	@echo "  sim-install      Build and install on the currently booted simulator"
-	@echo "  ipa-unsigned     Build unsigned IPA with XCUITest runner for real iOS devices"
+	@echo "  ipa-unsigned     Build unsigned runner IPA + main app IPA for real iOS devices"
 	@echo "  debug            Build with Debug configuration"
 	@echo "  release          Build with Release configuration"
 	@echo "  clean            Remove build artifacts"
@@ -65,6 +65,14 @@ ipa-unsigned:
 	@cd $(EXPORT_PATH) && zip -r $(SCHEME)-runner.ipa Payload
 	@rm -rf $(EXPORT_PATH)/Payload
 	@echo "Runner IPA created at: $(EXPORT_PATH)/$(SCHEME)-runner.ipa"
+	@echo "Packaging main app IPA..."
+	@rm -rf $(EXPORT_PATH)/Payload
+	@rm -f $(EXPORT_PATH)/$(SCHEME).ipa
+	@mkdir -p $(EXPORT_PATH)/Payload
+	@cp -r "$(BUILD_DIR)/Build/Products/$(CONFIGURATION)-iphoneos/$(SCHEME).app" $(EXPORT_PATH)/Payload/
+	@cd $(EXPORT_PATH) && zip -r $(SCHEME).ipa Payload
+	@rm -rf $(EXPORT_PATH)/Payload
+	@echo "App IPA created at: $(EXPORT_PATH)/$(SCHEME).ipa"
 
 # Build XCUITest runner for iOS Simulator (arm64 — Apple Silicon)
 sim-zip-arm64:


### PR DESCRIPTION
## Why
The autoscaler needs a **normal app** (`com.mobilenext.devicekit-ios`) as the Device Farm main `AppArn` — that's what makes Device Farm install the h264 auxiliary capture app. Using the XCTest runner there breaks iOS capture (`DeviceKit main app not found`, mobile-next/backend outage 2026-08-22). Right now that app has no tagged source: releases only ship `devicekit-ios-runner.ipa` + the sim zips.

## Root cause
The project has two targets — `devicekit-ios` (main app) and `devicekit-iosUITests` (runner). `make ipa-unsigned` runs `build-for-testing`, which compiles **both**, but the packaging step only zips `…UITests-Runner.app`. The main app is built into `Build/Products/Release-iphoneos/devicekit-ios.app` and thrown away (`scripts/patch-runner.sh` and `sim-install` both reference it, so it's definitely produced).

## Change
Package `devicekit-ios.app` → `devicekit-ios.ipa` in the same target. `build.yml` already uploads `build/export/*.ipa`, so tagged releases will include it automatically (and it gets provenance attestation like the runner). Verified locally: `make ipa-unsigned` now emits both `devicekit-ios.ipa` (com.mobilenext.devicekit-ios, ~538KB) and `devicekit-ios-runner.ipa`.