### PR TITLE
fix: sample the swipe path over its requested duration

### DIFF
--- a/DeviceKitTests/JSONRPC/Handlers/IOSwipe.swift
+++ b/DeviceKitTests/JSONRPC/Handlers/IOSwipe.swift
@@ -2,6 +2,7 @@ import os
 
 private enum Constants {
     static let defaultSwipeDuration = 0.1
+    static let maxSwipeDuration = 60.0
 }
 
 struct IOSwipeRequest: Decodable {
@@ -9,6 +10,7 @@ struct IOSwipeRequest: Decodable {
     let y1: Int
     let x2: Int
     let y2: Int
+    let duration: TimeInterval?
 }
 
 @MainActor
@@ -23,11 +25,21 @@ struct IOSwipeMethodHandler: RPCMethodHandler {
     func execute(params: JSONValue?) async throws -> JSONValue {
         let request = try decodeParams(IOSwipeRequest.self, from: params)
 
+        let duration = request.duration ?? Constants.defaultSwipeDuration
+        guard duration >= 0 else {
+            throw RPCMethodError.invalidParams("Duration cannot be negative, got \(duration)")
+        }
+        guard duration <= Constants.maxSwipeDuration else {
+            throw RPCMethodError.invalidParams(
+                "Duration \(duration) exceeds the maximum of \(Constants.maxSwipeDuration) seconds"
+            )
+        }
+
         do {
             try await swipePrivateAPI(
                 start: CGPoint(x: request.x1, y: request.y1),
                 end: CGPoint(x: request.x2, y: request.y2),
-                duration: Constants.defaultSwipeDuration
+                duration: duration
             )
 
             return .object(["success": .bool(true)])

--- a/DeviceKitTests/XCTest/EventRecord.swift
+++ b/DeviceKitTests/XCTest/EventRecord.swift
@@ -7,6 +7,9 @@ final class EventRecord: NSObject {
 
     static let defaultTapDuration = 0.1
 
+    static let swipeSampleRate: TimeInterval = 60
+    static let maxSwipeSamples = 240
+
     enum Style: String {
         case singleFinger = "Single-Finger Touch Action"
         case multiFinger = "Multi-Finger Touch Action"
@@ -35,10 +38,25 @@ final class EventRecord: NSObject {
     func addSwipeEvent(start: CGPoint, end: CGPoint, duration: TimeInterval) -> Self {
         var path = PointerEventPath.pathForTouch(at: start)
         path.offset += Self.defaultTapDuration
-        path.moveTo(point: end)
-        path.offset += duration
+
+        let sampleCount = Self.swipeSampleCount(for: duration)
+        let step = duration / TimeInterval(sampleCount)
+        for sample in 1...sampleCount {
+            let progress = CGFloat(sample) / CGFloat(sampleCount)
+            path.offset += step
+            path.moveTo(point: CGPoint(
+                x: start.x + (end.x - start.x) * progress,
+                y: start.y + (end.y - start.y) * progress
+            ))
+        }
+
         path.liftUp()
         return add(path)
+    }
+
+    private static func swipeSampleCount(for duration: TimeInterval) -> Int {
+        let sampled = Int((duration * Self.swipeSampleRate).rounded())
+        return min(max(sampled, 1), Self.maxSwipeSamples)
     }
 
     func add(_ path: PointerEventPath) -> Self {

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ All methods follow the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) spe
 | Method | Description |
 |--------|-------------|
 | `device.io.tap` | Tap at (x, y) coordinates |
-| `device.io.swipe` | Swipe from (x1, y1) to (x2, y2) with an optional duration |
+| `device.io.swipe` | Swipe from (x1, y1) to (x2, y2) with an optional duration in seconds (default 0.1, max 60) |
 | `device.io.longpress` | Long press at (x, y) for a duration |
 | `device.io.gesture` | Multi-finger gesture with press/move/release actions |
 | `device.io.text` | Type text into the focused field |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ All methods follow the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) spe
 | Method | Description |
 |--------|-------------|
 | `device.io.tap` | Tap at (x, y) coordinates |
-| `device.io.swipe` | Swipe from (x1, y1) to (x2, y2) |
+| `device.io.swipe` | Swipe from (x1, y1) to (x2, y2) with an optional duration |
 | `device.io.longpress` | Long press at (x, y) for a duration |
 | `device.io.gesture` | Multi-finger gesture with press/move/release actions |
 | `device.io.text` | Type text into the focused field |

--- a/tests/rpc.test.ts
+++ b/tests/rpc.test.ts
@@ -152,8 +152,36 @@ test.describe("device.io.swipe", () => {
     expect(result).toBeTruthy();
   });
 
+  test("swipes over an explicit duration", async ({ request }) => {
+    const started = Date.now();
+    const result = returnsResult(
+      await rpc(request, "device.io.swipe", {
+        x1: 200,
+        y1: 400,
+        x2: 200,
+        y2: 200,
+        duration: 1.5,
+      }),
+    );
+    expect(result).toBeTruthy();
+    expect(Date.now() - started).toBeGreaterThanOrEqual(1400);
+  });
+
   test("fails without coordinates", async ({ request }) => {
     const error = returnsError(await rpc(request, "device.io.swipe"));
+    expect(error.code).toBeTruthy();
+  });
+
+  test("rejects a negative duration", async ({ request }) => {
+    const error = returnsError(
+      await rpc(request, "device.io.swipe", {
+        x1: 200,
+        y1: 400,
+        x2: 200,
+        y2: 200,
+        duration: -1,
+      }),
+    );
     expect(error.code).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- `addSwipeEvent` registered the `moveTo` at the touch-settle offset and advanced the clock only afterwards, so every swipe arrived in 0.1s and then waited there. `duration` was already plumbed through, but it meant "hold at the end point", not "travel for this long".
- The travel is now sampled across the requested duration (60 samples per second, capped at 240), which also gives UIKit the intermediate touches it uses for fling velocity. `device.io.swipe` takes an optional `duration` in seconds, defaulting to the previous 0.1.

Verified on an iPhone 11 (iOS 26.6), iPhone 12 mini (iOS 18.6) and iPhone 13 (iOS 26.6)