### PR TITLE
feat: device.clipboard.get and device.clipboard.set handlers

### DIFF
--- a/DeviceKitTests/JSONRPC/Handlers/ClipboardGet.swift
+++ b/DeviceKitTests/JSONRPC/Handlers/ClipboardGet.swift
@@ -1,0 +1,21 @@
+import Foundation
+import os
+
+@MainActor
+struct ClipboardGetMethodHandler: RPCMethodHandler {
+    static let methodName = "device.clipboard.get"
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: String(describing: Self.self)
+    )
+
+    func execute(params: JSONValue?) async throws -> JSONValue {
+        let text = try await Pasteboard.withRunnerInForeground {
+            try await Pasteboard.readText()
+        }
+
+        logger.info("Clipboard returned \(text.count) character(s)")
+        return .object(["text": .string(text)])
+    }
+}

--- a/DeviceKitTests/JSONRPC/Handlers/ClipboardSet.swift
+++ b/DeviceKitTests/JSONRPC/Handlers/ClipboardSet.swift
@@ -1,0 +1,27 @@
+import Foundation
+import os
+
+struct ClipboardSetRequest: Codable {
+    let text: String
+}
+
+@MainActor
+struct ClipboardSetMethodHandler: RPCMethodHandler {
+    static let methodName = "device.clipboard.set"
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: String(describing: Self.self)
+    )
+
+    func execute(params: JSONValue?) async throws -> JSONValue {
+        let request = try decodeParams(ClipboardSetRequest.self, from: params)
+
+        try await Pasteboard.withRunnerInForeground {
+            try Pasteboard.write(request.text)
+        }
+
+        logger.info("Clipboard set to \(request.text.count) character(s)")
+        return .object(["success": .bool(true)])
+    }
+}

--- a/DeviceKitTests/JSONRPC/JSONRPCDispatcher.swift
+++ b/DeviceKitTests/JSONRPC/JSONRPCDispatcher.swift
@@ -28,6 +28,8 @@ final class JSONRPCDispatcher {
         registerHandler(IOOrientationSetMethodHandler())
         registerHandler(DeviceInfoMethodHandler())
         registerHandler(AppsForegroundMethodHandler())
+        registerHandler(ClipboardGetMethodHandler())
+        registerHandler(ClipboardSetMethodHandler())
     }
 
     func registerHandler<T: RPCMethodHandler>(_ handler: T) {

--- a/DeviceKitTests/XCTest/Pasteboard.swift
+++ b/DeviceKitTests/XCTest/Pasteboard.swift
@@ -8,6 +8,27 @@ private enum Constants {
     static let alertCheckInterval: TimeInterval = 0.5
 }
 
+private actor SerialGate {
+    private var isBusy = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        if !isBusy {
+            isBusy = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            isBusy = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
 private final class PasteboardRead: @unchecked Sendable {
     private let lock = NSLock()
     private var storedText: String?
@@ -38,10 +59,25 @@ struct Pasteboard {
 
     private init() {}
 
-    // iOS only hands the general pasteboard to the foreground application, so
-    // the runner is brought forward for the access and whatever was in front
-    // before is restored afterwards.
+    // @MainActor allows reentrancy at every await, so two overlapping HTTP
+    // requests could otherwise interleave activation/access/restoration —
+    // e.g. one call restoring the previous app while another is still
+    // waiting on pasteboard access. The gate serializes the whole operation.
+    private static let gate = SerialGate()
+
     static func withRunnerInForeground<T>(_ body: () async throws -> T) async throws -> T {
+        await gate.acquire()
+        do {
+            let result = try await performInForeground(body)
+            await gate.release()
+            return result
+        } catch {
+            await gate.release()
+            throw error
+        }
+    }
+
+    private static func performInForeground<T>(_ body: () async throws -> T) async throws -> T {
         guard let runnerBundleId = Bundle.main.bundleIdentifier else {
             throw RPCMethodError.internalError("Cannot determine the runner bundle identifier")
         }
@@ -89,7 +125,7 @@ struct Pasteboard {
 
         if text.isEmpty {
             pasteboard.items = []
-            guard !pasteboard.hasStrings else {
+            guard pasteboard.numberOfItems == 0 else {
                 throw failure
             }
         } else {
@@ -134,13 +170,13 @@ struct Pasteboard {
             return
         }
 
+        // Picked by position, not label, so this doesn't depend on device language.
         let buttons = alert.buttons
-        let count = buttons.count
-        guard count > 0 else {
+        guard buttons.count > 0 else {
             return
         }
 
         logger.info("Accepting the pasteboard consent alert")
-        buttons.element(boundBy: count - 1).tap()
+        buttons.element(boundBy: buttons.count - 1).tap()
     }
 }

--- a/DeviceKitTests/XCTest/Pasteboard.swift
+++ b/DeviceKitTests/XCTest/Pasteboard.swift
@@ -1,0 +1,146 @@
+import Foundation
+import UIKit
+import XCTest
+import os
+
+private enum Constants {
+    static let alertTimeout: TimeInterval = 30
+    static let alertCheckInterval: TimeInterval = 0.5
+}
+
+private final class PasteboardRead: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedText: String?
+    private var isFinished = false
+
+    var finished: Bool {
+        lock.withLock { isFinished }
+    }
+
+    var text: String? {
+        lock.withLock { storedText }
+    }
+
+    func complete(with text: String?) {
+        lock.withLock {
+            storedText = text
+            isFinished = true
+        }
+    }
+}
+
+@MainActor
+struct Pasteboard {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "devicekit-ios",
+        category: String(describing: Self.self)
+    )
+
+    private init() {}
+
+    // iOS only hands the general pasteboard to the foreground application, so
+    // the runner is brought forward for the access and whatever was in front
+    // before is restored afterwards.
+    static func withRunnerInForeground<T>(_ body: () async throws -> T) async throws -> T {
+        guard let runnerBundleId = Bundle.main.bundleIdentifier else {
+            throw RPCMethodError.internalError("Cannot determine the runner bundle identifier")
+        }
+
+        let runner = XCUIApplication(bundleIdentifier: runnerBundleId)
+        let previousBundleId = RunningApp.getForegroundApp()?.bundleID
+        let needsActivation = runner.state != .runningForeground
+
+        if needsActivation {
+            logger.info("Activating the runner for pasteboard access")
+            runner.activate()
+        }
+
+        do {
+            let result = try await body()
+            restore(previousBundleId, runnerBundleId: runnerBundleId, wasActivated: needsActivation)
+            return result
+        } catch {
+            restore(previousBundleId, runnerBundleId: runnerBundleId, wasActivated: needsActivation)
+            throw error
+        }
+    }
+
+    private static func restore(
+        _ previousBundleId: String?,
+        runnerBundleId: String,
+        wasActivated: Bool
+    ) {
+        guard wasActivated,
+              let previousBundleId = previousBundleId,
+              previousBundleId != runnerBundleId else {
+            return
+        }
+
+        logger.info("Restoring \(previousBundleId) to the foreground")
+        XCUIApplication(bundleIdentifier: previousBundleId).activate()
+    }
+
+    static func write(_ text: String) throws {
+        let pasteboard = UIPasteboard.general
+
+        let failure = RPCMethodError.internalError(
+            "Pasteboard write did not take effect; it is only available while the device is unlocked"
+        )
+
+        if text.isEmpty {
+            pasteboard.items = []
+            guard !pasteboard.hasStrings else {
+                throw failure
+            }
+        } else {
+            pasteboard.string = text
+            guard pasteboard.string == text else {
+                throw failure
+            }
+        }
+    }
+
+    static func readText() async throws -> String {
+        guard UIPasteboard.general.hasStrings else {
+            return ""
+        }
+
+        let read = PasteboardRead()
+        DispatchQueue.global().async {
+            read.complete(with: UIPasteboard.general.string)
+        }
+
+        let deadline = Date().addingTimeInterval(Constants.alertTimeout)
+        while !read.finished {
+            try await Task.sleep(nanoseconds: UInt64(Constants.alertCheckInterval * 1_000_000_000))
+            if read.finished {
+                break
+            }
+            acceptConsentAlert()
+            if Date() > deadline {
+                throw RPCMethodError.internalError(
+                    "Pasteboard read did not complete within \(Constants.alertTimeout)s"
+                )
+            }
+        }
+
+        return read.text ?? ""
+    }
+
+    private static func acceptConsentAlert() {
+        let springboard = XCUIApplication(bundleIdentifier: RunningApp.springboardBundleId)
+        let alert = springboard.alerts.firstMatch
+        guard alert.exists else {
+            return
+        }
+
+        let buttons = alert.buttons
+        let count = buttons.count
+        guard count > 0 else {
+            return
+        }
+
+        logger.info("Accepting the pasteboard consent alert")
+        buttons.element(boundBy: count - 1).tap()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ All methods follow the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) spe
 | `device.io.orientation.get` | Get current orientation (`PORTRAIT` / `LANDSCAPE`) |
 | `device.io.orientation.set` | Set orientation to `PORTRAIT` or `LANDSCAPE` |
 | `device.url` | Open a URL |
+| `device.clipboard.get` | Read the clipboard text |
+| `device.clipboard.set` | Replace the clipboard text |
 
 #### Apps
 

--- a/devicekit-ios.xcodeproj/project.pbxproj
+++ b/devicekit-ios.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		52D8FAB42D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 52D8FAB32D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.m */; };
 		52D8FAB52D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 52D8FAB22D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.h */; };
 		52E35D432A654F67001D97A8 /* RunningApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E35D422A654F67001D97A8 /* RunningApp.swift */; };
+		52E35D512A654F67001D97A9 /* Pasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E35D502A654F67001D97A9 /* Pasteboard.swift */; };
 		610D58FB2A49E3CA00B4BBEB /* AXClientSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610D58FA2A49E3CA00B4BBEB /* AXClientSwizzler.swift */; };
 		6124329E2A4DA5BB00F5F619 /* AXElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6124329D2A4DA5BB00F5F619 /* AXElement.swift */; };
 		612DE40229801F71003C2BE0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 612DE40129801F71003C2BE0 /* XCTest.framework */; };
@@ -65,6 +66,8 @@
 		787C48482F228D960027A012 /* JSONRPCMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787C48472F228D950027A012 /* JSONRPCMessageHandler.swift */; };
 		787C95982F17F23500AB3BF1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 787C95972F17F23500AB3BF1 /* Assets.xcassets */; };
 		78A190B62F3A3ADA007F24E0 /* IOButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78A190B52F3A3ADA007F24E0 /* IOButton.swift */; };
+		78A190D32F3A3ADA007F24E2 /* ClipboardSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78A190D22F3A3ADA007F24E2 /* ClipboardSet.swift */; };
+		78A190D12F3A3ADA007F24E2 /* ClipboardGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78A190D02F3A3ADA007F24E2 /* ClipboardGet.swift */; };
 		78EA9F912F36611B008B17D3 /* AppsTerminate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78EA9F902F36611B008B17D3 /* AppsTerminate.swift */; };
 		78F689392F17EF1B0025C8AC /* devicekit_iosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F689372F17EF1B0025C8AC /* devicekit_iosApp.swift */; };
 		94826F4429DB082100795E9B /* SystemPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94826F4329DB082100795E9B /* SystemPermissionManager.swift */; };
@@ -118,6 +121,7 @@
 		52D8FAB22D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+FBQuiescence.h"; sourceTree = "<group>"; };
 		52D8FAB32D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplication+FBQuiescence.m"; sourceTree = "<group>"; };
 		52E35D422A654F67001D97A8 /* RunningApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningApp.swift; sourceTree = "<group>"; };
+		52E35D502A654F67001D97A9 /* Pasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pasteboard.swift; sourceTree = "<group>"; };
 		610D58FA2A49E3CA00B4BBEB /* AXClientSwizzler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AXClientSwizzler.swift; sourceTree = "<group>"; };
 		6124329D2A4DA5BB00F5F619 /* AXElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXElement.swift; sourceTree = "<group>"; };
 		612DE40129801F71003C2BE0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -148,6 +152,8 @@
 		787C48472F228D950027A012 /* JSONRPCMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCMessageHandler.swift; sourceTree = "<group>"; };
 		787C95972F17F23500AB3BF1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		78A190B52F3A3ADA007F24E0 /* IOButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOButton.swift; sourceTree = "<group>"; };
+		78A190D22F3A3ADA007F24E2 /* ClipboardSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardSet.swift; sourceTree = "<group>"; };
+		78A190D02F3A3ADA007F24E2 /* ClipboardGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardGet.swift; sourceTree = "<group>"; };
 		78EA9F902F36611B008B17D3 /* AppsTerminate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsTerminate.swift; sourceTree = "<group>"; };
 		78F689132F17EE190025C8AC /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		78F689372F17EF1B0025C8AC /* devicekit_iosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = devicekit_iosApp.swift; sourceTree = "<group>"; };
@@ -308,6 +314,7 @@
 				612DE413298426EF003C2BE0 /* EventRecord.swift */,
 				613E87D6299A64BD00FF8551 /* PointerEventPath.swift */,
 				52E35D422A654F67001D97A8 /* RunningApp.swift */,
+				52E35D502A654F67001D97A9 /* Pasteboard.swift */,
 			);
 			path = XCTest;
 			sourceTree = "<group>";
@@ -336,6 +343,8 @@
 				781480362F27CEF000E61E3B /* Screenshot.swift */,
 				7814800A2F27C55500E61E3B /* IOLongpress.swift */,
 				78A190B52F3A3ADA007F24E0 /* IOButton.swift */,
+				78A190D22F3A3ADA007F24E2 /* ClipboardSet.swift */,
+				78A190D02F3A3ADA007F24E2 /* ClipboardGet.swift */,
 				78147FCA2F27C03500E61E3B /* IOSwipe.swift */,
 				7865E50E2F42596200D0F45F /* AppsForeground.swift */,
 				78147F3C2F27BDBC00E61E3B /* AppsLaunch.swift */,
@@ -516,6 +525,8 @@
 				787C47E02F228B770027A012 /* DumpUI.swift in Sources */,
 				521C1F102D8051FC0024EE42 /* XCTestDaemonsProxy.m in Sources */,
 				78A190B62F3A3ADA007F24E0 /* IOButton.swift in Sources */,
+				78A190D32F3A3ADA007F24E2 /* ClipboardSet.swift in Sources */,
+				78A190D12F3A3ADA007F24E2 /* ClipboardGet.swift in Sources */,
 				613E87D7299A64BD00FF8551 /* PointerEventPath.swift in Sources */,
 				78147FCB2F27C04400E61E3B /* IOSwipe.swift in Sources */,
 				787C48482F228D960027A012 /* JSONRPCMessageHandler.swift in Sources */,
@@ -539,6 +550,7 @@
 				78E4A1B12F5C110200D4F1AA /* IOKeys.swift in Sources */,
 				6124329E2A4DA5BB00F5F619 /* AXElement.swift in Sources */,
 				52E35D432A654F67001D97A8 /* RunningApp.swift in Sources */,
+				52E35D512A654F67001D97A9 /* Pasteboard.swift in Sources */,
 				52D8FAB42D6DD54F0015FAB3 /* XCUIApplication+FBQuiescence.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tests/rpc.test.ts
+++ b/tests/rpc.test.ts
@@ -339,6 +339,29 @@ test.describe("device.url", () => {
 });
 
 // ---------------------------------------------------------------------------
+// device.clipboard
+// ---------------------------------------------------------------------------
+test.describe("device.clipboard", () => {
+  test("reads back what it wrote", async ({ request }) => {
+    const text = `devicekit-${Date.now()}`;
+    returnsResult(await rpc(request, "device.clipboard.set", { text }));
+    const result = returnsResult(await rpc(request, "device.clipboard.get"));
+    expect(result.text).toBe(text);
+  });
+
+  test("returns empty text after setting an empty clipboard", async ({ request }) => {
+    returnsResult(await rpc(request, "device.clipboard.set", { text: "" }));
+    const result = returnsResult(await rpc(request, "device.clipboard.get"));
+    expect(result.text).toBe("");
+  });
+
+  test("fails without text", async ({ request }) => {
+    const error = returnsError(await rpc(request, "device.clipboard.set"));
+    expect(error.code).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // error handling
 // ---------------------------------------------------------------------------
 test.describe("error handling", () => {


### PR DESCRIPTION
## Summary
WebDriverAgent exposes `getPasteboard`/`setPasteboard` and the Android agent has clipboard access; iOS had none. Adds `device.clipboard.get` and `device.clipboard.set`.

- iOS only hands `UIPasteboard.general` to the foreground app — from the background runner reads come back empty and writes are dropped silently (`PBErrorDomain` code 10). The runner is activated for the access and the previous app restored afterwards, skipped when it is already frontmost.
- Reading content owned by another app raises the system paste consent alert and blocks until answered, so the read runs off the main thread while the handler dismisses the alert by tapping the last button — by position, not label, so device language does not matter.
- `set` reads the value back and fails with an explicit error instead of reporting success, since a locked device drops writes without raising anything.