### PR TITLE
docs: update changelog 0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.25](https://github.com/mobile-next/devicekit-ios/releases/tag/0.0.25) (2026-08-25)
+* Feat: device.clipboard.get and device.clipboard.set handlers ([#64](https://github.com/mobile-next/devicekit-ios/pull/64)), thanks to [@hakanor](https://github.com/hakanor)
+
 ## [0.0.24](https://github.com/mobile-next/devicekit-ios/releases/tag/0.0.24) (2026-08-22)
 * Fix: sample the swipe path over its requested duration ([#62](https://github.com/mobile-next/devicekit-ios/pull/62)), thanks to [@hakanor](https://github.com/hakanor)
 * Build: package main app (devicekit-ios.ipa) in ipa-unsigned so releases ship it ([#61](https://github.com/mobile-next/devicekit-ios/pull/61))


### PR DESCRIPTION
Adds the 0.0.25 changelog entry: device.clipboard.get and device.clipboard.set handlers (#64), credited to @hakanor.