### PR TITLE
feat: include enabled, selected and hasFocus in json ui dump

### DIFF
--- a/DeviceKitTests/XCTest/AXElement.swift
+++ b/DeviceKitTests/XCTest/AXElement.swift
@@ -37,7 +37,7 @@ struct SourceTreeElement: Codable {
         self.placeholderValue = axElement.placeholderValue
         self.rawIdentifier = identifier
         // only emit state attributes when they differ from the default, to keep the tree small
-        self.enabled = axElement.enabled ? nil : false
+        self.enabled = axElement.enabled == false ? false : nil
         self.selected = axElement.selected ? true : nil
         self.hasFocus = axElement.hasFocus ? true : nil
         self.rect = SourceTreeRect(frame: axElement.frame)
@@ -96,7 +96,8 @@ struct AXElement: Codable {
     let title: String?
     let label: String
     let elementType: Int
-    let enabled: Bool
+    // nil when XCTest did not report the attribute, so unknown is not confused with disabled
+    let enabled: Bool?
     let horizontalSizeClass: Int
     let verticalSizeClass: Int
     let placeholderValue: String?
@@ -121,7 +122,7 @@ struct AXElement: Codable {
         self.placeholderValue = nil
         self.value = nil
         self.frame = .zero
-        self.enabled = false
+        self.enabled = nil
         self.title = nil
     }
 
@@ -132,7 +133,7 @@ struct AXElement: Codable {
         title: String?,
         label: String,
         elementType: Int,
-        enabled: Bool,
+        enabled: Bool?,
         horizontalSizeClass: Int,
         verticalSizeClass: Int,
         placeholderValue: String?,
@@ -176,7 +177,7 @@ struct AXElement: Codable {
         self.placeholderValue = valueFor("placeholderValue") as? String
         self.value = valueFor("value") as? String
         self.frame = valueFor("frame") as? AXFrame ?? .zero
-        self.enabled = valueFor("enabled") as? Bool ?? false
+        self.enabled = valueFor("enabled") as? Bool
         self.title = valueFor("title") as? String
         let childrenDictionaries =
             valueFor("children") as? [[XCUIElement.AttributeName: Any]]
@@ -191,7 +192,7 @@ struct AXElement: Codable {
         try container.encodeIfPresent(self.title, forKey: .title)
         try container.encode(self.label, forKey: .label)
         try container.encode(self.elementType, forKey: .elementType)
-        try container.encode(self.enabled, forKey: .enabled)
+        try container.encodeIfPresent(self.enabled, forKey: .enabled)
         try container.encode(
             self.horizontalSizeClass,
             forKey: .horizontalSizeClass

--- a/DeviceKitTests/XCTest/AXElement.swift
+++ b/DeviceKitTests/XCTest/AXElement.swift
@@ -22,6 +22,9 @@ struct SourceTreeElement: Codable {
     let value: String?
     let placeholderValue: String?
     let rawIdentifier: String?
+    let enabled: Bool?
+    let selected: Bool?
+    let hasFocus: Bool?
     let rect: SourceTreeRect
     let children: [SourceTreeElement]?
 
@@ -33,6 +36,10 @@ struct SourceTreeElement: Codable {
         self.value = axElement.value
         self.placeholderValue = axElement.placeholderValue
         self.rawIdentifier = identifier
+        // only emit state attributes when they differ from the default, to keep the tree small
+        self.enabled = axElement.enabled ? nil : false
+        self.selected = axElement.selected ? true : nil
+        self.hasFocus = axElement.hasFocus ? true : nil
         self.rect = SourceTreeRect(frame: axElement.frame)
         self.children = axElement.children?.isEmpty == true ? nil : axElement.children?.map { SourceTreeElement(axElement: $0) }
     }


### PR DESCRIPTION
The json format of `device.dump.ui` dropped the state attributes that are present in the raw tree, so consumers cannot tell a disabled button from an enabled one.

`SourceTreeElement` now carries `enabled`, `selected` and `hasFocus`. They are emitted sparsely — `enabled` only when false, `selected`/`hasFocus` only when true — to keep the tree small and to match the convention mobilecli already uses for Android.

Needed by https://github.com/mobile-next/mobilewright/issues/271.

Test plan: `xcodebuild build-for-testing` succeeds; dump a screen with a disabled button and confirm `"enabled": false` appears in `--format json`.