### PR TITLE
feat: include enabled, selected and focused state attributes in json ui dump

### DIFF
--- a/DeviceKitTests/JSONRPC/Handlers/DumpUI.swift
+++ b/DeviceKitTests/JSONRPC/Handlers/DumpUI.swift
@@ -104,7 +104,11 @@ struct DumpUIMethodHandler: RPCMethodHandler {
         excludeKeyboardElements: Bool
     ) throws -> AXElement {
         SystemPermissionManager.handleSystemPermissionAlertIfNeeded(foregroundApp: foregroundApp)
-        let appHierarchy = try getHierarchyWithFallback(foregroundApp)
+        var appHierarchy = try getHierarchyWithFallback(foregroundApp)
+
+        if let focusedFrame = keyboardFocusedElementFrame(foregroundApp) {
+            appHierarchy.markKeyboardFocus(at: focusedFrame)
+        }
 
         let statusBars = logger.measure(message: "Fetch status bar hierarchy") {
             fullStatusBars(springboardApplication)
@@ -166,6 +170,26 @@ struct DumpUIMethodHandler: RPCMethodHandler {
             windowContextID: element.windowContextID,
             children: adjustedChildren
         )
+    }
+
+    // the snapshot's hasFocus attribute is tvOS-only; on iOS the element
+    // holding keyboard focus is only reachable through a predicate query
+    // against the private hasKeyboardFocus property, same as WebDriverAgent
+    private func keyboardFocusedElementFrame(_ app: XCUIApplication) -> AXFrame? {
+        let focused = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "hasKeyboardFocus == true"))
+            .firstMatch
+        guard focused.exists else {
+            return nil
+        }
+
+        let frame = focused.frame
+        return [
+            "X": Double(frame.minX),
+            "Y": Double(frame.minY),
+            "Width": Double(frame.width),
+            "Height": Double(frame.height),
+        ]
     }
 
     private func getHierarchyWithFallback(_ element: XCUIElement) throws -> AXElement {

--- a/DeviceKitTests/XCTest/AXElement.swift
+++ b/DeviceKitTests/XCTest/AXElement.swift
@@ -102,7 +102,7 @@ struct AXElement: Codable {
     let verticalSizeClass: Int
     let placeholderValue: String?
     let selected: Bool
-    let hasFocus: Bool
+    var hasFocus: Bool
     var children: [AXElement]?
     let windowContextID: Double
     let displayID: Int
@@ -182,6 +182,20 @@ struct AXElement: Codable {
         let childrenDictionaries =
             valueFor("children") as? [[XCUIElement.AttributeName: Any]]
         self.children = childrenDictionaries?.map { AXElement($0) } ?? []
+    }
+
+    // the snapshot's hasFocus attribute is the tvOS focus engine and is always
+    // false on iPhone/iPad; keyboard focus is resolved by a separate query and
+    // stamped onto the node with the matching frame
+    mutating func markKeyboardFocus(at focusedFrame: AXFrame) {
+        if frame == focusedFrame {
+            hasFocus = true
+        }
+        children = children?.map {
+            var child = $0
+            child.markKeyboardFocus(at: focusedFrame)
+            return child
+        }
     }
 
     func encode(to encoder: Encoder) throws {

--- a/DeviceKitTests/XCTest/AXElement.swift
+++ b/DeviceKitTests/XCTest/AXElement.swift
@@ -37,7 +37,7 @@ struct SourceTreeElement: Codable {
         self.placeholderValue = axElement.placeholderValue
         self.rawIdentifier = identifier
         // only emit state attributes when they differ from the default, to keep the tree small
-        self.enabled = axElement.enabled ? nil : false
+        self.enabled = axElement.enabled == false ? false : nil
         self.selected = axElement.selected ? true : nil
         self.hasFocus = axElement.hasFocus ? true : nil
         self.rect = SourceTreeRect(frame: axElement.frame)
@@ -96,7 +96,8 @@ struct AXElement: Codable {
     let title: String?
     let label: String
     let elementType: Int
-    let enabled: Bool
+    // nil when XCTest did not report the attribute, so unknown is not confused with disabled
+    let enabled: Bool?
     let horizontalSizeClass: Int
     let verticalSizeClass: Int
     let placeholderValue: String?
@@ -121,7 +122,7 @@ struct AXElement: Codable {
         self.placeholderValue = nil
         self.value = nil
         self.frame = .zero
-        self.enabled = false
+        self.enabled = nil
         self.title = nil
     }
 
@@ -132,7 +133,7 @@ struct AXElement: Codable {
         title: String?,
         label: String,
         elementType: Int,
-        enabled: Bool,
+        enabled: Bool?,
         horizontalSizeClass: Int,
         verticalSizeClass: Int,
         placeholderValue: String?,
@@ -176,7 +177,7 @@ struct AXElement: Codable {
         self.placeholderValue = valueFor("placeholderValue") as? String
         self.value = valueFor("value") as? String
         self.frame = valueFor("frame") as? AXFrame ?? .zero
-        self.enabled = valueFor("enabled") as? Bool ?? false
+        self.enabled = valueFor("enabled") as? Bool
         self.title = valueFor("title") as? String
         let childrenDictionaries =
             valueFor("children") as? [[XCUIElement.AttributeName: Any]]
@@ -191,7 +192,7 @@ struct AXElement: Codable {
         try container.encodeIfPresent(self.title, forKey: .title)
         try container.encode(self.label, forKey: .label)
         try container.encode(self.elementType, forKey: .elementType)
-        try container.encode(self.enabled, forKey: .enabled)
+        try container.encodeIfPresent(self.enabled, forKey: .enabled)
         try container.encode(
             self.horizontalSizeClass,
             forKey: .horizontalSizeClass

--- a/DeviceKitTests/XCTest/AXElement.swift
+++ b/DeviceKitTests/XCTest/AXElement.swift
@@ -22,6 +22,9 @@ struct SourceTreeElement: Codable {
     let value: String?
     let placeholderValue: String?
     let rawIdentifier: String?
+    let enabled: Bool?
+    let selected: Bool?
+    let hasFocus: Bool?
     let rect: SourceTreeRect
     let children: [SourceTreeElement]?
 
@@ -33,6 +36,10 @@ struct SourceTreeElement: Codable {
         self.value = axElement.value
         self.placeholderValue = axElement.placeholderValue
         self.rawIdentifier = identifier
+        // only emit state attributes when they differ from the default, to keep the tree small
+        self.enabled = axElement.enabled ? nil : false
+        self.selected = axElement.selected ? true : nil
+        self.hasFocus = axElement.hasFocus ? true : nil
         self.rect = SourceTreeRect(frame: axElement.frame)
         self.children = axElement.children?.isEmpty == true ? nil : axElement.children?.map { SourceTreeElement(axElement: $0) }
     }


### PR DESCRIPTION
## Summary
- Emit `enabled` (only when false), `selected` and `hasFocus` (only when true) in the json ui dump, keeping the tree small
- Keep an unreported `enabled` attribute as unknown instead of defaulting to false
- Resolve keyboard focus with a `hasKeyboardFocus == true` predicate query (same approach as WebDriverAgent) and stamp the matching node — the snapshot's `hasFocus` attribute is the tvOS focus engine and is always false on iPhone/iPad

## Test plan
- [x] Verified on simulator with the Playground app (Basic UI): focused text field reports `hasFocus: true`, disabled button reports `enabled: false`, active segment reports `selected: true`