### PR TITLE
ci: fill github release description from CHANGELOG.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,9 @@ jobs:
       attestations: write
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
     - name: Download IPA artifacts
       uses: actions/download-artifact@v5
       with:
@@ -101,12 +104,16 @@ jobs:
           *.ipa
           *-Sim-*.zip
 
+    - name: Extract release notes from CHANGELOG.md
+      run: awk -v tag="$GITHUB_REF_NAME" '/^## \[/{f = ($0 ~ "^## \\[" tag "\\]")} f' CHANGELOG.md > release-notes.md
+
     - name: Upload to GitHub Release
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: Version ${{ github.ref_name }}
+        body_path: release-notes.md
         files: |
           *.ipa
           *-Sim-*.zip


### PR DESCRIPTION
## Summary

The release job created releases with an empty description. Now it extracts the tagged version's section from CHANGELOG.md and uses it as the release body.

## Changes

- Add checkout to the release job (it had none, so CHANGELOG.md was unavailable)
- Extract the tag's section with awk into release-notes.md
- Pass body_path to softprops/action-gh-release

## Testing

Verified the awk extraction locally against tag 0.0.25. If a tag has no CHANGELOG entry, the body is empty — same as today.

https://claude.ai/code/session_01HAaFNGwaEHiXjE38cLxnvY