### PR TITLE
fix: mirror swift concurrency runtime into runner below ios 15

### DIFF
--- a/scripts/patch-runner.sh
+++ b/scripts/patch-runner.sh
@@ -45,6 +45,14 @@ if [ -n "${XCODE_PLATFORM}" ]; then
     fi
 fi
 
+# Below iOS 15 XCTest needs libswift_Concurrency in the runner's Frameworks too, or it hangs.
+for lib in "${RUNNER_APP}"/PlugIns/*.xctest/Frameworks/libswift*.dylib; do
+    [ -f "${lib}" ] || continue
+    mkdir -p "${RUNNER_APP}/Frameworks"
+    cp "${lib}" "${RUNNER_APP}/Frameworks/"
+    echo "note: mirrored $(basename "${lib}") into runner Frameworks"
+done
+
 # Set display name
 /usr/bin/plutil -replace CFBundleDisplayName -string "Device Kit" "${RUNNER_APP}/Info.plist"
 


### PR DESCRIPTION
Below iOS 15 the OS ships no libswift_Concurrency.dylib, so Xcode embeds a copy inside the .xctest bundle only — but XCTestCore, XCUIAutomation and Testing link it too and resolve their rpaths against the runner app's Frameworks. The link is weak, so dyld says nothing: the symbols bind to NULL and the runner hangs before the first test suite, with no crash and no log after Running tests.... This mirrors those dylibs up into the runner, next to the existing lib_TestingInterop.dylib copy that solves the same class of problem; at iOS 15+ nothing is embedded, the glob matches nothing and it's a no-op.

Lifted from a local iOS 13 setup where it's working — I haven't verified it against a physical iOS 14 device here.